### PR TITLE
Add typescript strict check typing options and watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,16 @@
         "./packages/*"
     ],
     "scripts": {
-        "start": "concurrently --kill-others-on-fail \"npm run start -w @adyen/adyen-fp-web\" \"npm run start -w @adyen/adyen-fp-web-playground\" --names \"lib,playground\"",
+        "start": "concurrently --kill-others-on-fail \"npm run type:watch\" \"npm run start -w @adyen/adyen-fp-web\" \"npm run start -w @adyen/adyen-fp-web-playground\" --names \"lib,playground\"",
         "build": "npm run build -w @adyen/adyen-fp-web",
         "lint": "npm run lint -w @adyen/adyen-fp-web",
         "test": "npm run test -w @adyen/adyen-fp-web",
         "test:watch": "npm run test:watch -w @adyen/adyen-fp-web",
         "test:coverage": "npm run test:coverage -w @adyen/adyen-fp-web ",
         "test:e2e": "npm run build && npm test:e2e -w @adyen/adyen-fp-web-e2e ",
-        "type-check": "npm run type-check -w @adyen/adyen-fp-web "
+        "type-check": "npm run type-check -w @adyen/adyen-fp-web ",
+        "type:watch": "npm run types:watch -w @adyen/adyen-fp-web "
+
     },
     "dependencies": {
         "concurrently": "^7.0.0"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -26,7 +26,8 @@
         "test:coverage": "npm run test -- --coverage",
         "type-check": "tsc --noEmit",
         "lint": "eslint 'src/**/*.{js,ts,tsx}' --quiet",
-        "lint:fix": "npm run lint -- --fix"
+        "lint:fix": "npm run lint -- --fix",
+        "types:watch": "npm run type-check -- --watch"
     },
     "devDependencies": {
         "@types/jest": "^27.4.0",

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -11,18 +11,25 @@
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
-        "strictNullChecks": false,
 
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+
+        // TODO Delete all of the options below to use strict type checking
         "noImplicitAny": false,
-        "strictPropertyInitialization": false,
-        "suppressImplicitAnyIndexErrors": true,
+        "strictFunctionTypes":  false,
+        "strictNullChecks": false,
+        "strictPropertyInitialization":  false,
+        "noImplicitThis": false,
+
         "stripInternal": true,
-
         "importHelpers": true,
-
         "sourceMap": true,
-        "baseUrl": "./"
+        "baseUrl": "./",
+        "paths": {
+            "react": ["./node_modules/preact/compat/"]
+        }
     },
-    "include": ["src/"],
+    "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "tests/**/*.ts"],
     "exclude": ["node_modules", "**/*.test.*"]
 }


### PR DESCRIPTION
## Summary

Added `strict: true` in the tsconfig file to start using strict checking.

TODO: delete the following options to enable strict type checking options. 

```
"noImplicitAny"
"strictFunctionTypes"
"strictNullChecks"
"strictPropertyInitialization"
 "noImplicitThis"
```

This approach will allow us to enable the strict checking by parts.