### PR TITLE
Delete noImplicitThis rule in TSconfig

### DIFF
--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -17,6 +17,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         this.onSubmit = this.onSubmit.bind(this);
         this.componentRef = null;
         this.elementRef = (props && props.elementRef) || this;
+        this.triggerValidation = undefined;
     }
 
     public setState(newState: object): void {
@@ -36,6 +37,10 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     private onSubmit(): void {
         //
     }
+
+    private triggerValidation: (() => void) | undefined;
+
+    private setUIElementStatus: ((status: string) => void) | undefined;
 
     private onValid() {
         const state = { data: this.data };
@@ -60,13 +65,23 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     }
 
     public showValidation(): this {
-        if (this.componentRef && this.componentRef.showValidation) this.componentRef.showValidation();
+        if (this.componentRef?.showValidation) {
+            this.componentRef.showValidation();
+        } else {
+            this.triggerValidation?.();
+        }
         return this;
     }
+
+    public setTriggerValidation = (callBack: () => void) => {
+        this.triggerValidation = callBack;
+    };
 
     public setStatus(status: UIElementStatus, props: P): this {
         if (this.componentRef?.setStatus) {
             this.componentRef.setStatus(status, props);
+        } else {
+            this.setUIElementStatus?.(status);
         }
         return this;
     }

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -77,7 +77,7 @@ export default function Address(props: AddressProps<AddressData>) {
         props.onChange?.({ data: processedData, valid, errors, isValid });
     }, [props.data, data, valid, errors, isValid]);
 
-    this.showValidation = triggerValidation;
+    props.setTriggerValidation?.(triggerValidation);
 
     if (visibility === 'hidden') return null;
     if (visibility === 'readOnly') return <ReadOnlyAddress data={data} label={label} />;

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -4,6 +4,7 @@ import { ValidatorRules } from '../../../utils/Validator/types';
 import { ValidationRuleResult } from '../../../utils/Validator/ValidationRuleResult';
 import { FormState, SchemaKeys } from '../../../utils/useForm/types';
 import { TargetedEvent } from 'preact/compat';
+import { SetTriggerValidation } from '../../types';
 
 // Describes an object with unknown keys whose value is always a string
 export type StringObject = {
@@ -23,6 +24,7 @@ export interface AddressProps<FormSchema extends Record<string, any>> {
     visibility?: string;
     overrideSchema?: AddressSpecifications;
     iOSFocusedField?: string;
+    setTriggerValidation?: SetTriggerValidation;
 }
 
 export interface AddressState<FormSchema extends Record<string, any>> {

--- a/packages/lib/src/components/internal/CompanyDetails/CompanyDetails.tsx
+++ b/packages/lib/src/components/internal/CompanyDetails/CompanyDetails.tsx
@@ -42,7 +42,7 @@ export default function CompanyDetails(props: CompanyDetailsProps<CompanyDetails
         props.onChange({ data: formattedData, valid, errors, isValid });
     }, [data, valid, errors, isValid]);
 
-    this.showValidation = triggerValidation;
+    props.setTriggerValidation?.(triggerValidation);
 
     if (visibility === 'hidden') return null;
     if (visibility === 'readOnly') return <ReadOnlyCompanyDetails {...props} data={data} />;

--- a/packages/lib/src/components/internal/CompanyDetails/types.ts
+++ b/packages/lib/src/components/internal/CompanyDetails/types.ts
@@ -1,6 +1,7 @@
 import { FieldsetVisibility } from '../../../types';
 import { ValidatorRules } from '../../../utils/Validator/types';
 import { SchemaKeys } from '../../../utils/useForm/types';
+import { SetTriggerValidation } from '../../types';
 
 export type CompanyDetailsSchema = {
     name?: string;
@@ -17,6 +18,7 @@ export interface CompanyDetailsProps<FormSchema extends Record<string, any>> {
     readonly?: boolean;
     ref?: any;
     validationRules?: ValidatorRules<FormSchema>;
+    setTriggerValidation?: SetTriggerValidation;
 }
 
 export interface ReadOnlyCompanyDetailsProps {

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -64,7 +64,7 @@ export default function PersonalDetails(props: PersonalDetailsProps<PersonalDeta
         onChange?.({ data: formattedData, valid, errors, isValid });
     }, [data, valid, errors, isValid]);
 
-    this.showValidation = triggerValidation;
+    props.setTriggerValidation?.(triggerValidation);
 
     if (visibility === 'hidden') return null;
     if (visibility === 'readOnly') return <ReadOnlyPersonalDetails {...props} data={data} />;

--- a/packages/lib/src/components/internal/PersonalDetails/types.ts
+++ b/packages/lib/src/components/internal/PersonalDetails/types.ts
@@ -1,5 +1,6 @@
 import { FieldsetVisibility, PersonalDetailsSchema } from '../../../types';
 import { ValidatorRules } from '../../../utils/Validator/types';
+import { SetTriggerValidation } from '../../types';
 
 type PersonalDetailsPlaceholders = Omit<PersonalDetailsSchema, 'gender'>;
 
@@ -14,6 +15,7 @@ export interface PersonalDetailsProps<FormSchema extends Record<string, any>> {
     readonly?: boolean;
     ref?: any;
     validationRules?: ValidatorRules<FormSchema>;
+    setTriggerValidation?: SetTriggerValidation;
 }
 
 export interface PersonalDetailsStateError {

--- a/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
@@ -27,8 +27,9 @@ export function PhoneInput(props: PhoneInputComponentProps) {
         props.onChange({ data, valid, errors, isValid });
     }, [data, valid, errors, isValid]);
 
-    this.showValidation = triggerValidation;
-    this.setStatus = setStatus;
+    props.setTriggerValidation?.(triggerValidation);
+    props.setUIElementStatus?.(setStatus);
+
     return (
         <div className="adyen-fp-phone-input">
             <Field
@@ -77,7 +78,7 @@ export function PhoneInput(props: PhoneInputComponentProps) {
                     </div>
                 </div>
             </Field>
-            {this.props.showPayButton && this.props.payButton({ status })}
+            {props.showPayButton && props.payButton({ status })}
         </div>
     );
 }

--- a/packages/lib/src/components/internal/PhoneInput/types.ts
+++ b/packages/lib/src/components/internal/PhoneInput/types.ts
@@ -1,9 +1,11 @@
 import Language from '../../../language/Language';
+import { SetTriggerValidation } from '../../types';
+import { StateUpdater } from 'preact/compat';
 
 export interface PhoneInputComponentProps {
     onChange: (state: Record<string, any>) => void;
     onValid: () => void;
-    payButton: () => void;
+    payButton: (args: { status: string }) => void;
     phoneLabel?: string;
     selected: string;
     items: [];
@@ -17,6 +19,8 @@ export interface PhoneInputComponentProps {
         phonePrefix: string;
         phoneNumber: string;
     };
+    setTriggerValidation?: SetTriggerValidation;
+    setUIElementStatus?: (callback: StateUpdater<string>) => void;
 }
 
 export interface PhoneInputState {

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -51,7 +51,7 @@ function PhoneInput(props: PhoneInputProps<PhoneInputSchema>) {
         props.onChange({ data, valid, errors, isValid });
     }, [data, valid, errors, isValid]);
 
-    this.triggerValidation = triggerValidation;
+    props.setTriggerValidation?.(triggerValidation);
 
     /**
      * The <Field> element assigns a uniqueId which it uses for the \<label for=\> attribute.

--- a/packages/lib/src/components/internal/PhoneInputNew/types.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/types.ts
@@ -1,6 +1,6 @@
 import { DataSet, DataSetItem } from '../../../core/Services/data-set';
 import { SchemaKeys } from '../../../utils/useForm/types';
-import { Ref } from 'preact/compat';
+import { Ref, StateUpdater } from 'preact/compat';
 import AdyenFPError from '../../../core/Errors/AdyenFPError';
 
 export type PhoneInputSchema = {
@@ -23,6 +23,7 @@ export interface PhoneInputProps<FormSchema extends Record<string, any>> {
         phoneNumber?: string;
     };
     ref?: Ref<HTMLElement>;
+    setTriggerValidation?: (callback: StateUpdater<string>) => void;
 }
 
 export interface PhonePrefixes {

--- a/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
+++ b/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
@@ -6,9 +6,7 @@ function RedirectButton({ payButton, onSubmit, amount, name, ...props }: Redirec
     const { i18n } = useCoreContext();
     const [status, setStatus] = useState('ready');
 
-    this.setStatus = (newStatus: string) => {
-        setStatus(newStatus);
-    };
+    props.setUIElementStatus?.((newStatus: string) => setStatus(newStatus));
 
     const payButtonLabel = () => {
         const isZeroAuth = amount && {}.hasOwnProperty.call(amount, 'value') && amount.value === 0;

--- a/packages/lib/src/components/internal/RedirectButton/types.ts
+++ b/packages/lib/src/components/internal/RedirectButton/types.ts
@@ -5,4 +5,5 @@ export interface RedirectButtonProps {
         value: number;
     };
     name: string;
+    setUIElementStatus?: (callback: (status: string) => void) => void;
 }

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -26,6 +26,8 @@ export interface IUIElement {
 
 export type UIElementStatus = 'ready' | 'loading' | 'error' | 'success';
 
+export type SetTriggerValidation = (callback: (schema?: Record<string, any>) => void) => void;
+
 export interface UIElementProps extends BaseElementProps {
     id?: string;
     session?: BPSession;
@@ -41,6 +43,8 @@ export interface UIElementProps extends BaseElementProps {
     icon?: string;
     amount?: Amount;
     secondaryAmount?: AmountExtended;
+    triggerValidation?: SetTriggerValidation;
+    setUIElementStatus?: (status: string) => void;
 
     /**
      * Show/Hide pay button

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -14,10 +14,7 @@
 
         "strict": true,
         "noUncheckedIndexedAccess": true,
-
-        // TODO Delete all of the options below to use strict type checking
-        "noImplicitThis": false,
-
+        
         "stripInternal": true,
         "importHelpers": true,
         "sourceMap": true,


### PR DESCRIPTION
More type errors fixes, continuing the effort to enable strict type checking. This time getting rid of the `noImplicitThis` option in the TS config file. 

With this PR, strict type checking will be enabled for the entire project. 

PRs related: [#16](https://github.com/Adyen/adyen-fp-web/pull/16) - [#17](https://github.com/Adyen/adyen-fp-web/pull/17) - [#18](https://github.com/Adyen/adyen-fp-web/pull/18) - [19](https://github.com/Adyen/adyen-fp-web/pull/19) - [21](https://github.com/Adyen/adyen-fp-web/pull/21) - [23](https://github.com/Adyen/adyen-fp-web/pull/23) - [24](https://github.com/Adyen/adyen-fp-web/pull/24)

**Fixed issue**:  [FOS-501](https://youtrack.is.adyen.com/issue/FOS-501)

