### PR TITLE
Enable Preact devtools

### DIFF
--- a/packages/lib/src/core/index.ts
+++ b/packages/lib/src/core/index.ts
@@ -1,1 +1,4 @@
+if (process.env.NODE_ENV === 'development') {
+    require('preact/debug');
+}
 export { default } from './core';


### PR DESCRIPTION
## Summary
Enabling the preact devtools to have an easier way to debug components. 