### PR TITLE
Patch usePaginatedRecords hook to correct anomalies

### DIFF
--- a/packages/lib/src/components/internal/Pagination/hooks/usePaginatedRecords.ts
+++ b/packages/lib/src/components/internal/Pagination/hooks/usePaginatedRecords.ts
@@ -32,7 +32,7 @@ const isCursorPaginatedResponseData = <T, DataField extends string>(
 
     const dataProperties = Object.getOwnPropertyNames(data as PaginatedResponseDataWithLinks<T, DataField>);
 
-    return offsetPaginatedResponseFields.some(prop => dataProperties.includes(prop));
+    return !offsetPaginatedResponseFields.some(prop => dataProperties.includes(prop));
 };
 
 const parseCursorPaginatedResponseData = <T, DataField extends string>(
@@ -108,7 +108,7 @@ const usePaginatedRecords = <T, DataField extends string, FilterValue extends st
     onPageRequest,
     pagination,
 }: BasePaginatedRecordsInitOptions<T, DataField, FilterValue, FilterParam>): UsePaginatedRecords<T, FilterValue, FilterParam> => {
-    const [pageLimit, setPageLimit] = useState(limit);
+    const [pageLimit, setPageLimit] = useState(data?.[dataField]?.length ?? limit);
     const [records, setRecords] = useState<T[]>([]);
     const [fetching, updateFetching] = useBooleanState(true);
     const [shouldRefresh, updateShouldRefresh] = useBooleanState(false);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
- Fixed a bug in the `isCursorPaginatedResponseData` helper that causes some responses with one or more offset pagination fields to be erroneously taken to be cursor paginated responses.

- Fixed a bug that causes infinite recursion (in some scenario) when the initial records are received as a result of a mismatch between the length of the records received and the specified page limit.

<!-- ## Tested scenarios
<!-- Description of tested scenarios -->


<!-- **Fixed issue**:  <!-- #-prefixed issue number -->
