### PR TITLE
Address ESLint technical debt

### DIFF
--- a/packages/lib/src/components/internal/Pagination/hooks/usePaginatedRecords.ts
+++ b/packages/lib/src/components/internal/Pagination/hooks/usePaginatedRecords.ts
@@ -83,10 +83,13 @@ const createAwaitable = <T>() => {
             await ($promise = new Promise(resolve => {
                 $resolve = resolve;
             }));
-        } finally {
-            // eslint-disable-next-line no-unsafe-finally
-            return refresh();
+        } catch {
+            /**
+             * Ignore the promise rejection — the goal is to guarantee that a new pending promise is created in its
+             * place the moment it is settled. The rejection will be handled later at the usage site of the promise.
+             */
         }
+        return refresh();
     })();
 
     return Object.create(null, {

--- a/packages/lib/src/utils/amount-util.test.ts
+++ b/packages/lib/src/utils/amount-util.test.ts
@@ -1,3 +1,4 @@
+import { CurrencyCode } from '@src/utils/constants/currency-codes';
 import { isValidCurrencyCode, getCurrencyCode, getLocalisedAmount, getLocalisedPercentage, getDivider } from './amount-util';
 import { beforeAll, afterEach, afterAll, describe, expect, test, vi, SpyInstance } from 'vitest';
 
@@ -17,9 +18,7 @@ describe('getDivider', () => {
         expect(getDivider('USD')).toBe(100);
         expect(getDivider('JPY')).toBe(1);
         expect(getDivider('BHD')).toBe(1000);
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore - TODO: check if below should be here since it is not part of the currency codes
-        expect(getDivider('MRO')).toBe(10);
+        expect(getDivider('MRO' as CurrencyCode)).toBe(10);
     });
 });
 

--- a/packages/lib/src/utils/useForm/useForm.test.tsx
+++ b/packages/lib/src/utils/useForm/useForm.test.tsx
@@ -1,7 +1,3 @@
-//TODO get rid of the following two comments once the tests are fixed
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import useForm from './useForm';
 import { renderHook, act } from '@testing-library/preact';
 import { Form } from './types';
@@ -10,14 +6,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 //TODO enable this test in a dedicated PR
 describe.skip('useForm', () => {
     const defaultSchema = ['firstName', 'lastName'];
-    type defaultSchemaType = {
-        firstName: string;
-        lastName: string;
-    };
-    const defaultData = { firstName: 'John' };
+    type DefaultSchemaType = { [key: string]: string };
+    const defaultData: Partial<DefaultSchemaType> = { firstName: 'John' };
 
     describe('schema', () => {
-        let useFormHook;
+        let useFormHook: { current: Form<Record<string, any>> };
         beforeEach(() => {
             const { result } = renderHook(() => useForm({ schema: defaultSchema }));
             useFormHook = result;
@@ -25,12 +18,12 @@ describe.skip('useForm', () => {
 
         it('should set a default schema', () => {
             expect(useFormHook.current.schema).toEqual(defaultSchema);
-            expect(useFormHook.current.data[defaultSchema[0]]).toEqual(null);
-            expect(useFormHook.current.errors[defaultSchema[0]]).toEqual(null);
-            expect(useFormHook.current.valid[defaultSchema[0]]).toEqual(false);
-            expect(useFormHook.current.data[defaultSchema[1]]).toEqual(null);
-            expect(useFormHook.current.valid[defaultSchema[1]]).toEqual(false);
-            expect(useFormHook.current.errors[defaultSchema[1]]).toEqual(null);
+            expect(useFormHook.current.data[defaultSchema[0] as string]).toEqual(null);
+            expect(useFormHook.current.errors[defaultSchema[0] as string]).toEqual(null);
+            expect(useFormHook.current.valid[defaultSchema[0] as string]).toEqual(false);
+            expect(useFormHook.current.data[defaultSchema[1] as string]).toEqual(null);
+            expect(useFormHook.current.valid[defaultSchema[1] as string]).toEqual(false);
+            expect(useFormHook.current.errors[defaultSchema[1] as string]).toEqual(null);
         });
 
         it('should update the schema', () => {
@@ -47,7 +40,7 @@ describe.skip('useForm', () => {
 
     describe('defaultData', () => {
         it('should set defaultData', () => {
-            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema, defaultData }));
+            const { result } = renderHook<Form<DefaultSchemaType>, Form<DefaultSchemaType>>(() => useForm({ schema: defaultSchema, defaultData }));
 
             expect(result.current.data.firstName).toEqual(defaultData.firstName);
             expect(result.current.data.lastName).toEqual(null);
@@ -78,7 +71,7 @@ describe.skip('useForm', () => {
         const firstNameValue = 'John';
 
         it('should handle changes for a field', () => {
-            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema }));
+            const { result } = renderHook<Form<DefaultSchemaType>, Form<DefaultSchemaType>>(() => useForm({ schema: defaultSchema }));
 
             act(() => {
                 result.current.handleChangeFor('firstName')(firstNameValue);
@@ -123,7 +116,7 @@ describe.skip('useForm', () => {
         });
 
         it('should set the value of a checkbox', () => {
-            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema }));
+            const { result } = renderHook<Form<DefaultSchemaType>, Form<DefaultSchemaType>>(() => useForm({ schema: defaultSchema }));
             const mockEvent = { target: { type: 'checkbox' } };
 
             // call once to set to "checked"

--- a/packages/lib/src/utils/uuid.ts
+++ b/packages/lib/src/utils/uuid.ts
@@ -1,9 +1,7 @@
-/* eslint-disable */
 export default function uuidv4(): string {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-        let r = (Math.random() * 16) | 0,
+        const r = (Math.random() * 16) | 0,
             v = c == 'x' ? r : (r & 0x3) | 0x8;
         return v.toString(16);
     });
 }
-/* eslint-enable */


### PR DESCRIPTION
This PR fixes the outstanding ESLint issues/warnings that are being suppressed using eslint-disable-* directives.

Fixed issue: [FOS-756](https://youtrack.is.adyen.com/issue/FOS-756/Address-ESLint-technical-debt)
