### PR TITLE
Refactor core context (switch to function syntax)

### DIFF
--- a/packages/lib/src/core/Context/CoreContext.ts
+++ b/packages/lib/src/core/Context/CoreContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'preact';
-import { CommonPropsTypes } from './CoreProvider';
+import { CommonPropsTypes } from './types';
 import Language from '../../language/Language';
 
 export const CoreContext = createContext({ i18n: new Language(), loadingContext: '', commonProps: {} as CommonPropsTypes });

--- a/packages/lib/src/core/Context/types.ts
+++ b/packages/lib/src/core/Context/types.ts
@@ -1,0 +1,10 @@
+export interface CommonPropsTypes {
+    isCollatingErrors?: boolean;
+}
+
+export interface CoreProviderProps {
+    children?: any;
+    commonProps?: CommonPropsTypes;
+    i18n: any;
+    loadingContext?: string;
+}

--- a/packages/lib/src/core/Context/useCoreContext.ts
+++ b/packages/lib/src/core/Context/useCoreContext.ts
@@ -1,8 +1,6 @@
 import { useContext } from 'preact/hooks';
 import { CoreContext } from './CoreContext';
 
-function useCoreContext() {
-    return useContext(CoreContext);
-}
+const useCoreContext = () => useContext(CoreContext);
 
 export default useCoreContext;


### PR DESCRIPTION
## Summary
Minor refactoring of the core context — switching from class syntax to function syntax with Preact hooks. This PR is a precursor to some updates that will be made to the core context to accommodate timezone configuration.

**Related to:**  **[PIE-36: Add a way to specify a timezone/offset](https://youtrack.is.adyen.com/issue/PIE-36)**
