### PR TITLE
Add missing config in the tsconfig.json of the playground

### DIFF
--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -16,5 +16,6 @@
         "types": ["vite/client"]
     },
     "include": ["*.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
-    "exclude": ["node_modules", "**/*.test.*", "dist"]
+    "exclude": ["node_modules", "**/*.test.*", "dist"],
+    "references": [{ "path": "../lib" }]
 }


### PR DESCRIPTION
## Summary
This small change fixes a problem with the typing in the playground when using any IDE. Now it recognizes immediately the type changes.