### PR TITLE
Fix queryParams in endpoint calls

### DIFF
--- a/packages/lib/src/components/external/Transactions/types.ts
+++ b/packages/lib/src/components/external/Transactions/types.ts
@@ -6,9 +6,8 @@ import { TranslationKey } from '../../../core/Localization/types';
 import { ModalSize } from '../../internal/Modal/types';
 
 export const enum TransactionFilterParam {
-    ACCOUNT_HOLDER = 'accountHolderId',
-    BALANCE_ACCOUNT = 'balanceAccountId',
-    BALANCE_PLATFORM_ID = 'balancePlatform',
+    CATEGORIES = 'categories',
+    STATUSES = 'statuses',
     CREATED_SINCE = 'createdSince',
     CREATED_UNTIL = 'createdUntil',
 }

--- a/packages/lib/src/core/Services/requests/http.ts
+++ b/packages/lib/src/core/Services/requests/http.ts
@@ -14,7 +14,7 @@ export function http<T>(options: HttpOptions, data?: any): Promise<T> {
     if (options.params) {
         options.params.forEach((value, param) => {
             const decodedValue = decodeURIComponent(value);
-            if (decodedValue) url.searchParams.set(param, decodedValue);
+            if (decodedValue) url.searchParams.append(param, decodedValue);
         });
     }
 

--- a/packages/lib/src/core/Services/requests/utils.ts
+++ b/packages/lib/src/core/Services/requests/utils.ts
@@ -67,9 +67,19 @@ export function isAdyenErrorResponse(data: any): data is AdyenErrorResponse {
 }
 
 export function parseSearchParams<T extends Record<string, any>>(parameters: T) {
-    const params: Record<string, string> = {};
-    for (const param in parameters) {
-        if (parameters[param]) params[param] = String(parameters[param]);
+    const params = new URLSearchParams();
+
+    for (const param of Object.keys(parameters)) {
+        const value = parameters[param];
+        if (value) {
+            if (Array.isArray(value)) {
+                value.forEach(item => params.append(param, item));
+            } else {
+                // For non-array values, just set the key and value normally
+                params.set(param, value);
+            }
+        }
     }
-    return new URLSearchParams(params);
+
+    return params;
 }

--- a/packages/lib/src/hooks/useSetupEndpoint/useSetupEndpoint.ts
+++ b/packages/lib/src/hooks/useSetupEndpoint/useSetupEndpoint.ts
@@ -44,9 +44,8 @@ export const useSetupEndpoint = <Endpoint extends EndpointName, Operation extend
                 const pathParamKey = Object.keys(pathParam)[0]!;
                 path = path.replace(`{${pathParamKey}}`, pathParam[pathParamKey]);
             }
-
             return httpProvider<SuccessResponse<Operation>>(
-                { loadingContext, path, ...requestOptions, ...parseSearchParams(params) },
+                { loadingContext, path, ...requestOptions, params: params.query && parseSearchParams(params.query) },
                 (operation.method as HttpMethod) ?? 'GET'
             );
         },

--- a/packages/playground/src/endpoints/mock-server/transactions.ts
+++ b/packages/playground/src/endpoints/mock-server/transactions.ts
@@ -5,7 +5,26 @@ import { delay } from '../utils/utils';
 
 export const transactionsMocks = [
     rest.get(endpoints.transactions, (req, res, ctx) => {
-        return res(delay(400), ctx.json({ transactions: BASIC_TRANSACTIONS_LIST }));
+        let transactions = BASIC_TRANSACTIONS_LIST;
+
+        const categories = req.url.searchParams.getAll('categories');
+        const statuses = req.url.searchParams.getAll('statuses');
+
+        if (categories.length && statuses.length) {
+            return res(
+                delay(400),
+                ctx.json({ transactions: transactions.filter(tx => categories.includes(tx.category) && statuses.includes(tx.status)) })
+            );
+        } else {
+            if (categories.length) {
+                transactions = transactions.filter(tx => categories.includes(tx.category));
+            }
+            if (statuses.length) {
+                transactions = transactions.filter(tx => statuses.includes(tx.status));
+            }
+        }
+
+        return res(delay(400), ctx.json({ transactions }));
     }),
     rest.get(endpoints.transaction, (req, res, ctx) => {
         const matchingMock = [...BASIC_TRANSACTIONS_LIST, TRANSACTION_DETAILS_DEFAULT].find(mock => mock.id === req.params.id);

--- a/packages/playground/src/endpoints/mock-server/utils.ts
+++ b/packages/playground/src/endpoints/mock-server/utils.ts
@@ -11,7 +11,14 @@ const MOCK_MODES = ['mocked', 'demo'];
 export async function enableServerInMockedMode(enabled?: boolean) {
     const env = (import.meta as any).env;
     if (enabled || MOCK_MODES.includes(env.VITE_MODE || env.MODE)) {
-        await mockWorker.start({});
+        await mockWorker.start({
+            onUnhandledRequest: (request, print) => {
+                if (request.url.pathname.includes('images/logos/') || request.url.pathname.includes('node_modules')) return;
+
+                // Otherwise, print a warning that an API request is not correctly mocked
+                print.warning();
+            },
+        });
     }
 }
 export function stopMockedServer() {


### PR DESCRIPTION
## Summary

- This PR fixes a problem with the `searchParams` in the `useSetupEndpoint` hook.
- Updated the mocked endpoint call of the transactions to filter by statuses and categories.
- Add temporary select component to filter by individual status or category.