### PR TITLE
Fix totals and balances amount style

### DIFF
--- a/packages/lib/src/components/external/Transactions/components/SummaryItem/SummaryItem.scss
+++ b/packages/lib/src/components/external/Transactions/components/SummaryItem/SummaryItem.scss
@@ -15,6 +15,10 @@
         color: var(--adyen-fp-color-label-secondary);
     }
 
+    &__amount {
+        white-space: nowrap;
+    }
+
     &__placeholder {
         display: inline-block;
         height: 12px;

--- a/packages/lib/src/components/external/Transactions/components/SummaryItem/SummaryItem.tsx
+++ b/packages/lib/src/components/external/Transactions/components/SummaryItem/SummaryItem.tsx
@@ -6,7 +6,13 @@ import './SummaryItem.scss';
 import AmountSkeleton from '@src/components/external/Transactions/components/AmountSkeleton/AmountSkeleton';
 import { useEffect } from 'preact/hooks';
 import { SummaryItemProps } from '@src/components/external/Transactions/components/SummaryItem/types';
-import { BASE_CLASS, BODY_CLASS, LABEL_CLASS, PLACEHOLDER_CLASS } from '@src/components/external/Transactions/components/SummaryItem/constants';
+import {
+    AMOUNT_CLASS,
+    BASE_CLASS,
+    BODY_CLASS,
+    LABEL_CLASS,
+    PLACEHOLDER_CLASS,
+} from '@src/components/external/Transactions/components/SummaryItem/constants';
 
 export const SummaryItem = ({
     columnConfigs,
@@ -46,7 +52,7 @@ export const SummaryItem = ({
                         <div ref={config.ref} style={getColumnStyle(index)}>
                             <Typography
                                 variant={config.valueHasLabelStyle ? TypographyVariant.CAPTION : TypographyVariant.TITLE}
-                                className={classNames({ [LABEL_CLASS]: config.valueHasLabelStyle })}
+                                className={classNames(AMOUNT_CLASS, { [LABEL_CLASS]: config.valueHasLabelStyle })}
                             >
                                 {config.getValue()}
                             </Typography>

--- a/packages/lib/src/components/external/Transactions/components/SummaryItem/constants.ts
+++ b/packages/lib/src/components/external/Transactions/components/SummaryItem/constants.ts
@@ -1,4 +1,5 @@
 export const BASE_CLASS = 'adyen-fp-summary-item';
 export const BODY_CLASS = BASE_CLASS + '--body';
 export const LABEL_CLASS = BASE_CLASS + '__label';
+export const AMOUNT_CLASS = BASE_CLASS + '__amount';
 export const PLACEHOLDER_CLASS = BASE_CLASS + '__placeholder';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Previously we merged a fix about layout breaks for total and balances cards caused because max width was not reset when changing accounts (#151). However there is still a layout break happening: this time because the amount text is wrapped by default. This PR fixes this issue.

**Fixed issue**:  [PIE-272](https://youtrack.is.adyen.com/agiles/80-2576/84-33703?issue=PIE-272)
