### PR TITLE
Make Preact a peer dependency

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -97,7 +97,9 @@
     },
     "dependencies": {
         "classnames": "^2.3.1",
-        "core-js": "^3.20.2",
+        "core-js": "^3.20.2"
+    },
+    "peerDependencies": {
         "preact": "^10.13.2"
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

This PR makes Preact a peer dependency so our package can be used without conflicts with Preact apps.
