### PR TITLE
Maintain hover state on expandable card

### DIFF
--- a/packages/lib/src/components/internal/ExpandableCard/ExpandableCard.tsx
+++ b/packages/lib/src/components/internal/ExpandableCard/ExpandableCard.tsx
@@ -76,7 +76,7 @@ const ExpandableCard = ({ renderHeader, children, filled, ...listeners }: PropsW
                     </BaseButton>
                     <BaseButton
                         id={CONTAINER_OVERLAY_ID}
-                        className={classNames(CONTAINER_CLASS, CONTAINER_OVERLAY_CLASS, {
+                        className={classNames(CONTAINER_CLASS, CONTAINER_BUTTON_CLASS, CONTAINER_OVERLAY_CLASS, {
                             [CONTAINER_FILLED_CLASS]: filled,
                             [CONTAINER_HIDDEN_CLASS]: !isOpen,
                         })}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR makes sure we have hover state on expandable card also when it is expanded.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  [PIE-287](https://youtrack.is.adyen.com/agiles/80-2576/84-33703?issue=PIE-287)
