### PR TITLE
Fix missing root color style for popovers

### DIFF
--- a/packages/lib/src/components/shared.scss
+++ b/packages/lib/src/components/shared.scss
@@ -1,13 +1,14 @@
 .adyen-pe {
+    &-component,
+    &-popover,
     &-title {
         color: var(--adyen-sdk-color-label-primary);
+    }
+
+    &-title {
         font-size: var(--adyen-sdk-font-size-700);
         font-weight: var(--adyen-sdk-font-size-600);
         line-height: var(--adyen-sdk-line-height-300);
         margin: 16px 0;
     }
-}
-
-.adyen-pe-component {
-    color: var(--adyen-sdk-color-label-primary);
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR fixes a missing color style bug (found during testing the package after release) for popovers (content outside the `.adyen-pe-component` root element).
