### PR TITLE
Add stripInternal option to tsconfig

### DIFF
--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -15,7 +15,8 @@
         "jsxImportSource": "preact",
         "jsx": "react-jsx",
 
-        "types": ["@testing-library/jest-dom", "node"]
+        "types": ["@testing-library/jest-dom", "node"],
+        "stripInternal": false
     },
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/core/Localization/translations/*.json", "tests/**/*.ts"],
     "exclude": ["node_modules", "dist", "config/inject-css.ts"]


### PR DESCRIPTION
Add stripInternal option to tsconfig to prevent the error on the build package types folder for the properties tagged as internal.