### PR TITLE
PIE-392: Limit the earliest startDate for payouts components

### DIFF
--- a/packages/lib/src/components/external/PayoutsOverview/components/PayoutsOverview/PayoutsOverview.tsx
+++ b/packages/lib/src/components/external/PayoutsOverview/components/PayoutsOverview/PayoutsOverview.tsx
@@ -109,6 +109,8 @@ export const PayoutsOverview = ({
         [updateDetails]
     );
 
+    const sinceDate = useMemo(() => new Date('2024-04-16T00:00:00.000Z').toString(), []);
+
     return (
         <div className={BASE_CLASS}>
             {!hideTitle && (
@@ -128,6 +130,7 @@ export const PayoutsOverview = ({
                     filters={filters}
                     nowTimestamp={nowTimestamp}
                     refreshNowTimestamp={refreshNowTimestamp}
+                    sinceDate={sinceDate}
                     updateFilters={updateFilters}
                 />
             </FilterBar>

--- a/packages/lib/src/components/external/TransactionsOverview/components/TransactionsOverview/TransactionsOverview.tsx
+++ b/packages/lib/src/components/external/TransactionsOverview/components/TransactionsOverview/TransactionsOverview.tsx
@@ -147,6 +147,12 @@ export const TransactionsOverview = ({
         [updateDetails, activeBalanceAccount]
     );
 
+    const sinceDate = useMemo(() => {
+        const date = new Date(nowTimestamp);
+        date.setMonth(date.getMonth() - 24);
+        return date.toString();
+    }, [nowTimestamp]);
+
     return (
         <div className={BASE_CLASS}>
             {!hideTitle && (
@@ -166,6 +172,7 @@ export const TransactionsOverview = ({
                     filters={filters}
                     nowTimestamp={nowTimestamp}
                     refreshNowTimestamp={refreshNowTimestamp}
+                    sinceDate={sinceDate}
                     updateFilters={updateFilters}
                 />
                 {/* Remove status filter temporarily */}

--- a/packages/lib/src/components/internal/FilterBar/filters/DateFilter/DateFilter.tsx
+++ b/packages/lib/src/components/internal/FilterBar/filters/DateFilter/DateFilter.tsx
@@ -13,15 +13,17 @@ type DataOverviewDateFilterProps = Pick<UsePaginatedRecords<any, string, FilterP
         timezone?: UseTimeRangeSelectionConfig['timezone'];
     };
 
-const DateFilter = ({
+const DateFilter = <T extends DateFilterProps = DateFilterProps>({
     timezone,
     canResetFilters,
     defaultParams,
     filters,
     nowTimestamp,
     refreshNowTimestamp,
+    sinceDate,
+    untilDate,
     updateFilters,
-}: DataOverviewDateFilterProps) => {
+}: Pick<T, 'sinceDate' | 'untilDate'> & DataOverviewDateFilterProps) => {
     const { i18n } = useCoreContext();
     const defaultTimeRangePreset = useMemo(() => i18n.get(defaultParams.current.defaultTimeRange), [i18n]);
     const [selectedTimeRangePreset, setSelectedTimeRangePreset] = useState(defaultTimeRangePreset);
@@ -55,18 +57,12 @@ const DateFilter = ({
 
     useMemo(() => !canResetFilters && setSelectedTimeRangePreset(defaultTimeRangePreset), [canResetFilters, defaultTimeRangePreset]);
 
-    const sinceDate = useMemo(() => {
-        const date = new Date(nowTimestamp);
-        date.setMonth(date.getMonth() - 24);
-        return date.toString();
-    }, [nowTimestamp]);
-
     return (
         <DateFilterCore
             label={i18n.get('dateRange')}
             name={FilterParam.CREATED_SINCE}
             sinceDate={sinceDate}
-            untilDate={new Date(nowTimestamp).toString()}
+            untilDate={untilDate ?? new Date(nowTimestamp).toString()}
             from={filters[FilterParam.CREATED_SINCE]}
             to={filters[FilterParam.CREATED_UNTIL]}
             selectedPresetOption={selectedTimeRangePreset}

--- a/scripts/translations/sort-json
+++ b/scripts/translations/sort-json
@@ -7,11 +7,7 @@ try {
     const sortedJSON = JSON.stringify(
         Object.fromEntries(
             Object.entries(SOURCE_OBJ)
-                .sort(([A], [B]) => {
-                    const a = A.toLowerCase();
-                    const b = B.toLowerCase();
-                    return a < b ? -1 : +(a > b);
-                })
+                .sort(([a], [b]) => a.localeCompare(b))
         )
     );
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR enforces that the earliest `createdSince` date obtainable from the date filter widget of the `PayoutsOverview` component is **April 16, 2024**.

> N/B: It includes a minor refactor to the sorting script for source translation JSON files.

**Fixed issue: [PIE-392: Limit the earliest startDate for payouts components](https://youtrack.is.adyen.com/issue/PIE-392/Limit-the-earliest-startDate-for-payouts-components)**
