### PR TITLE
Compute relative paths using Node script

### DIFF
--- a/scripts/translations/sort-translations-json.sh
+++ b/scripts/translations/sort-translations-json.sh
@@ -16,7 +16,7 @@ PROJECT_ROOT=$(realpath "$SCRIPT_DIR/../..")
 sort_json=$(realpath "$SCRIPT_DIR/sort-json")
 
 sort_translations_json() {
-    local relative_path=$(realpath -m --relative-to=$PROJECT_ROOT $1)
+    local relative_path=$(node -e "console.log(require('node:path').relative('$(realpath "$PROJECT_ROOT")', '$(realpath "$1")'))")
     local json_path=$(realpath "$PROJECT_ROOT/$relative_path")
 
     if [[ ! -r $json_path ]]; then


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR enforces a uniform way of computing relative paths using an inline Node script (based on the expectation that any machine running this project already has Node installed) as opposed to relying on the `realpath` binary.
