### PR TITLE
Stop lazy loading ModalContent

### DIFF
--- a/packages/lib/src/components/internal/DataOverviewDisplay/DataDetailsModal.tsx
+++ b/packages/lib/src/components/internal/DataOverviewDisplay/DataDetailsModal.tsx
@@ -1,11 +1,10 @@
 import Modal from '../Modal';
+import { useEffect } from 'preact/hooks';
+import { FC, PropsWithChildren } from 'preact/compat';
 import { popoverUtil } from '../Popover/utils/popoverUtil';
-import Spinner from '../Spinner';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import useModalDetails from '../../../hooks/useModalDetails/useModalDetails';
-import { FC, lazy, PropsWithChildren, Suspense } from 'preact/compat';
-import { useEffect } from 'preact/hooks';
-const ModalContent = lazy(() => import('../Modal/ModalContent/ModalContent'));
+import ModalContent from '../Modal/ModalContent/ModalContent';
 
 export interface DataOverviewDisplayProps {
     onContactSupport?: () => void;
@@ -14,6 +13,7 @@ export interface DataOverviewDisplayProps {
     resetDetails: ReturnType<typeof useModalDetails>['resetDetails'];
     className: string;
 }
+
 export const DataDetailsModal: FC<DataOverviewDisplayProps> = ({
     children,
     className,
@@ -22,11 +22,13 @@ export const DataDetailsModal: FC<DataOverviewDisplayProps> = ({
 }: PropsWithChildren<DataOverviewDisplayProps>) => {
     const { i18n } = useCoreContext();
     const isModalOpen = !!selectedDetail;
+
     useEffect(() => {
         if (isModalOpen) {
             popoverUtil.closeAll();
         }
     }, [isModalOpen]);
+
     return (
         <div className={className}>
             {children}
@@ -40,17 +42,7 @@ export const DataDetailsModal: FC<DataOverviewDisplayProps> = ({
                     headerWithBorder={false}
                     size={selectedDetail?.modalSize ?? 'large'}
                 >
-                    {selectedDetail && (
-                        <Suspense
-                            fallback={
-                                <span className={className + '__spinner-container'}>
-                                    <Spinner size={'medium'} />
-                                </span>
-                            }
-                        >
-                            <ModalContent {...selectedDetail?.selection} />
-                        </Suspense>
-                    )}
+                    {selectedDetail && <ModalContent {...selectedDetail?.selection} />}
                 </Modal>
             )}
         </div>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR removes unnecessary lazy loading of the `ModalContent` component.

> The bundle size of the `ModalContent` component is so negligible — so that there is no performance gain in loading it as a separate bundle as against bundling it with the main JS bundle.

![Screenshot 2024-06-03 at 10 01 54](https://github.com/Adyen/adyen-platform-experience-web/assets/117656861/e4a8361d-8de6-417b-b095-4f901502ea10)