### PR TITLE
Fix core options locale type

### DIFF
--- a/packages/lib/src/core/Auth/types.ts
+++ b/packages/lib/src/core/Auth/types.ts
@@ -5,11 +5,11 @@ interface AuthProviderBaseProps {
     children?: any;
     token: string;
     endpoints: SetupEndpoint;
-    sessionSetupError?: Core<any>['sessionSetupError'];
+    sessionSetupError?: Core['sessionSetupError'];
 }
 
 export interface AuthProviderProps extends AuthProviderBaseProps {
-    updateCore?: Core<any>['update'];
+    updateCore?: Core['update'];
 }
 
 export interface AuthContextProps extends AuthProviderBaseProps {

--- a/packages/lib/src/core/Localization/types.ts
+++ b/packages/lib/src/core/Localization/types.ts
@@ -27,6 +27,4 @@ export type Translations = {
     [key in TranslationKey]?: string;
 };
 
-export type CustomTranslations = {
-    [locale: string]: Translations;
-};
+export type CustomTranslations = Record<string, Translations>;

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -6,11 +6,11 @@ import Localization from './Localization';
 import BaseElement from '../components/external/BaseElement';
 import { EMPTY_OBJECT } from '../utils';
 
-class Core<AvailableTranslations extends LangFile[]> {
+class Core<AvailableTranslations extends LangFile[] = [], CustomTranslations extends {} = {}> {
     public static readonly version = process.env.VITE_VERSION!;
 
     public components: BaseElement<any>[] = [];
-    public options: CoreOptions<AvailableTranslations>;
+    public options: CoreOptions<AvailableTranslations, CustomTranslations>;
 
     public localization: Localization;
     public loadingContext: string;
@@ -22,7 +22,7 @@ class Core<AvailableTranslations extends LangFile[]> {
 
     // [TODO]: Change the error handling strategy.
 
-    constructor(options: CoreOptions<AvailableTranslations>) {
+    constructor(options: CoreOptions<AvailableTranslations, CustomTranslations>) {
         this.options = { environment: FALLBACK_ENV, ...options };
 
         this.isUpdatingSessionToken = false;

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -1,14 +1,15 @@
-import { SessionResponse } from './Session/types';
-import type { CustomTranslations } from './Localization/types';
-import { AnalyticsOptions } from './Analytics/types';
-import { LangFile } from './Localization/types';
-import { KeyOfRecord, WithReplacedUnderscoreOrDash } from '../utils/types';
+import type { SessionResponse } from './Session/types';
+import type { AnalyticsOptions } from './Analytics/types';
+import type { CustomTranslations as Translations, LangFile } from './Localization/types';
+import type { KeyOfRecord, WithReplacedUnderscoreOrDash } from '../utils/types';
 
-type CreateUnionOfAvailableTranslations<T extends LangFile[]> = T extends T
+type CreateLocalesUnionFromAvailableTranslations<T extends LangFile[]> = T extends T
     ? Extract<WithReplacedUnderscoreOrDash<KeyOfRecord<T[number]>, '_', '-'>, string> | 'en-US'
     : never;
 
-export interface CoreOptions<AvailableTranslations extends LangFile[]> {
+type CreateLocalesUnionFromCustomTranslations<T extends Translations> = Extract<KeyOfRecord<T extends Translations ? T : {}>, string>;
+
+interface _CoreOptions<AvailableTranslations extends LangFile[] = [], CustomTranslations extends Translations = {}> {
     /**
      * @internal
      */
@@ -28,7 +29,9 @@ export interface CoreOptions<AvailableTranslations extends LangFile[]> {
      * For adding a custom locale, see {@link https://docs.adyen.com/checkout/components-web/localization-components#create-localization | Create localization}.
      * @defaultValue 'en-US'
      */
-    locale?: AvailableTranslations extends AvailableTranslations ? CreateUnionOfAvailableTranslations<AvailableTranslations> : never;
+    locale?:
+        | (AvailableTranslations extends AvailableTranslations ? CreateLocalesUnionFromAvailableTranslations<AvailableTranslations> : never)
+        | (CustomTranslations extends CustomTranslations ? CreateLocalesUnionFromCustomTranslations<CustomTranslations> : never);
 
     onError?: (err: any) => any;
     onSessionCreate: () => Promise<SessionResponse>;
@@ -37,7 +40,10 @@ export interface CoreOptions<AvailableTranslations extends LangFile[]> {
      * Custom translations and localizations
      * See {@link https://docs.adyen.com/checkout/components-web/localization-components | Localizing Components}
      */
-    translations?: CustomTranslations;
+    translations?: CustomTranslations extends Translations ? CustomTranslations : Translations;
 }
+
+export interface CoreOptions<AvailableTranslations extends LangFile[] = [], CustomTranslations extends {} = {}>
+    extends _CoreOptions<AvailableTranslations, CustomTranslations extends Translations ? CustomTranslations : unknown> {}
 
 export type DevEnvironment = 'test' | 'live' | 'beta';

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -7,7 +7,9 @@ export * from './core';
 export * from './components';
 export * from './types';
 
-export async function AdyenPlatformExperience<AvailableTranslations extends LangFile[] = []>(props: CoreOptions<AvailableTranslations>) {
+export async function AdyenPlatformExperience<AvailableTranslations extends LangFile[] = [], CustomTranslations extends {} = {}>(
+    props: CoreOptions<AvailableTranslations, CustomTranslations>
+) {
     const core = new Core(props);
     return await core.initialize();
 }

--- a/packages/playground/.storybook/utils/create-adyenPE.ts
+++ b/packages/playground/.storybook/utils/create-adyenPE.ts
@@ -1,7 +1,7 @@
 import { CoreOptions } from '@adyen/adyen-platform-experience-web';
 import { AdyenPlatformExperience } from '@adyen/adyen-platform-experience-web';
 
-export const createAdyenPlatformExperience = async (context: CoreOptions) => {
+export const createAdyenPlatformExperience = async (context: CoreOptions<any>) => {
     const adyenSession = await AdyenPlatformExperience(context);
     return adyenSession;
 };

--- a/packages/playground/src/stories/utils/get-story-context.ts
+++ b/packages/playground/src/stories/utils/get-story-context.ts
@@ -2,7 +2,7 @@ import { StoryContext } from '@storybook/types';
 import { Core, CoreOptions } from '@adyen/adyen-platform-experience-web';
 import { PreactRenderer } from '@storybook/preact';
 
-export const getStoryContextAdyenPlatformExperience = (context: StoryContext<PreactRenderer, CoreOptions>): Core | undefined => {
+export const getStoryContextAdyenPlatformExperience = (context: StoryContext<PreactRenderer, CoreOptions<any>>): Core<any> | undefined => {
     const { AdyenPlatformExperience } = context.loaded;
     return AdyenPlatformExperience;
 };

--- a/packages/playground/src/utils/createLanguageButtons.tsx
+++ b/packages/playground/src/utils/createLanguageButtons.tsx
@@ -1,6 +1,6 @@
 import { Core } from '@adyen/adyen-platform-experience-web';
 
-export const createLanguageButtons = ({ locales, core }: { locales: string[]; core: Core }) => {
+export const createLanguageButtons = ({ locales, core }: { locales: string[]; core: Core<any, any> }) => {
     const pageContainer = document.querySelector('.playground-header');
 
     const container = `<div class="locale-selection-container"></div>`;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR fixes type inference for the `locale` field of the `CoreOptions` interface to ensure that it unites locales from both the `availableTranslations` and `translations` (custom translations) fields.

**Fixed issue: [PIE-424: Core options locale type should include custom translation locales](https://youtrack.is.adyen.com/issue/PIE-424/Core-options-locale-type-should-include-custom-translation-locales)**
