### PR TITLE
Fix payment method line height

### DIFF
--- a/packages/lib/src/components/external/TransactionDetails/components/TransactionData.scss
+++ b/packages/lib/src/components/external/TransactionDetails/components/TransactionData.scss
@@ -33,7 +33,7 @@
         align-items: center;
         display: flex;
         gap: style.token(spacer-030);
-        line-height: 0;
+        line-height: 1;
     }
 
     &__payment-method-detail {

--- a/packages/lib/src/components/external/TransactionsOverview/components/TransactionsTable/TransactionTable.scss
+++ b/packages/lib/src/components/external/TransactionsOverview/components/TransactionsTable/TransactionTable.scss
@@ -11,7 +11,7 @@
         align-items: center;
         display: flex;
         gap: style.token(spacer-030);
-        line-height: 0;
+        line-height: 1;
     }
 
     &__payment-method-logo-container {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR fixes `line-height` for the displayed payment method on both the transactions table and the transaction details view.
