### PR TITLE
Show the correct error message in case of network error instead of no data found message

### DIFF
--- a/packages/lib/src/components/internal/DataGrid/DataGrid.tsx
+++ b/packages/lib/src/components/internal/DataGrid/DataGrid.tsx
@@ -47,7 +47,7 @@ function DataGrid<
     return (
         <div style={{ width: '100%' }}>
             <DataGridProvider>
-                <DataGridTable {...props} />
+                <DataGridTable {...props} errorDisplay={errorDisplay} />
             </DataGridProvider>
         </div>
     );
@@ -95,7 +95,7 @@ function DataGridTable<
                         <DataGridBody<Items, Columns, ClickedField, CustomCells> {...props} columns={visibleCols as Columns} emptyBody={emptyBody} />
                     </div>
                     {showMessage &&
-                        (emptyBody ? (
+                        (emptyBody && !props.error ? (
                             <ErrorMessageDisplay
                                 title={props.emptyTableMessage?.title ?? 'thereAreNoResults'}
                                 message={props.emptyTableMessage?.message}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Show the correct error message in case of network error instead of no data found message

**Fixed issue**:  [PIE-416](https://youtrack.is.adyen.com/issue/PIE-416/When-there-is-a-network-error-show-the-error-instead-of-no-transactions-found)
