### PR TITLE
Fix double build

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -43,7 +43,7 @@
     },
     "scripts": {
         "start": "vite dev",
-        "build": "rm -rf ./dist && vite build --mode esm --config vite.config.ts && vite build --mode cjs --config vite.config.ts && npm run types:build",
+        "build": "rm -rf ./dist && vite build --config vite.config.ts && npm run types:build",
         "build:test": "npm run build && npm pack",
         "build:analyse": "vite build --mode analyse --config vite.config.ts",
         "test": "vitest --config vite.config.ts",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
 Vite will always run the esm and cjs builds when running vite build. The --mode flag
 is generally used to set different env variables based on the value of the flag


## Tested scenarios
I performed a diff comparison on the build outputs before and after my modifications, and found no differences.


**Fixed issue**:  <!-- #-prefixed issue number -->
