### PR TITLE
chore: move concurrently to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,14 +53,12 @@
         "translations:sort": "bash scripts/process-translations/sort-translations-json.sh",
         "prepare": "node ./prepare.js && bash ./scripts/process-package-lock.sh"
     },
-    "dependencies": {
-        "concurrently": "^7.0.0"
-    },
     "devDependencies": {
         "husky": "^7.0.4",
         "lint-staged": "^13.0.1",
         "vite": "^4.3.2",
-        "vite-plugin-checker": "^0.5.6"
+        "vite-plugin-checker": "^0.5.6",
+        "concurrently": "^7.0.0"
     },
     "msw": {
         "workerDirectory": "packages/playground/public"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Concurrently is only used in a dev environment and should therefore only be in the the dev dependencies.
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
