### PR TITLE
Fix transactions overview date filter timezone

### DIFF
--- a/src/components/external/TransactionsOverview/components/TransactionsOverview/TransactionsOverview.tsx
+++ b/src/components/external/TransactionsOverview/components/TransactionsOverview/TransactionsOverview.tsx
@@ -168,6 +168,7 @@ export const TransactionsOverview = ({
                     nowTimestamp={nowTimestamp}
                     refreshNowTimestamp={refreshNowTimestamp}
                     sinceDate={sinceDate}
+                    timezone={activeBalanceAccount?.timeZone}
                     updateFilters={updateFilters}
                 />
                 {/* Remove status filter temporarily */}

--- a/src/components/internal/DatePicker/components/TimeRangeSelector/TimeRangeSelector.tsx
+++ b/src/components/internal/DatePicker/components/TimeRangeSelector/TimeRangeSelector.tsx
@@ -22,8 +22,8 @@ const TimeRangeSelector = ({
     useEffect(() => {
         if (calendarRef?.current && from && to) {
             rangeSelectionInProgress.current = true;
-            calendarRef.current.from = new Date(from as string);
-            calendarRef.current.to = new Date(to as string);
+            calendarRef.current.from = new Date(from);
+            calendarRef.current.to = new Date(to);
         }
     }, [calendarRef, from, to]);
 

--- a/src/components/internal/DatePicker/components/TimeRangeSelector/useTimeRangeSelection.ts
+++ b/src/components/internal/DatePicker/components/TimeRangeSelector/useTimeRangeSelection.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'preact/hooks';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
-import useTimezoneAwareDateFormatting from '../../../../hooks/useTimezoneAwareDateFormatting';
 import type { RestampContext } from '../../../../../core/Localization/datetime/restamper';
 import type { TranslationKey } from '../../../../../core/Localization/types';
 import { RangeTimestamp, RangeTimestamps } from '../../../Calendar/calendar/timerange';
@@ -33,9 +32,8 @@ export const useTimeRangeSelection = ({
     timezone,
 }: UseTimeRangeSelectionConfig) => {
     const { i18n } = useCoreContext();
-    const { fullDateFormat } = useTimezoneAwareDateFormatting(timezone);
-    const [from, setFrom] = useState<string>();
-    const [to, setTo] = useState<string>();
+    const [from, setFrom] = useState<number>();
+    const [to, setTo] = useState<number>();
     const [selectedOption, setSelectedOption] = useState<string>();
     const NOW = useRef<typeof now>();
     const TZ = useRef<typeof timezone>();
@@ -66,12 +64,12 @@ export const useTimeRangeSelection = ({
             const ranges = getRangesForOption(option, selectionOptions);
             if (!ranges) return;
 
-            setFrom(fullDateFormat(ranges.from));
-            setTo(fullDateFormat(ranges.to));
+            setFrom(ranges.from);
+            setTo(ranges.to);
             setIsCustomSelection(false);
             setSelectedOption(option);
         },
-        [customOption, fullDateFormat, getRangesForOption, selectedOption, selectionOptions]
+        [customOption, getRangesForOption, selectedOption, selectionOptions]
     );
 
     const customSelection = useCallback(() => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR fixes timezone information for transactions overview date filter to reflect the active balance account timezone.

**Fixed issue: [CXP-454](https://youtrack.is.adyen.com/issue/CXP-454/Change-Transactions-Overview-date-filter-timezone-information-as-balance-account-timezone-information)**
