### PR TITLE
Remove seconds from dates in transactions table

### DIFF
--- a/src/components/external/PayoutsOverview/components/PayoutsTable/PayoutsTable.tsx
+++ b/src/components/external/PayoutsOverview/components/PayoutsTable/PayoutsTable.tsx
@@ -1,4 +1,4 @@
-import { DATE_FORMAT_PAYOUTS } from '../../../../internal/DataOverviewDisplay/constants';
+import { DATE_FORMAT_MOBILE_PAYOUTS, DATE_FORMAT_PAYOUTS } from '../../../../internal/DataOverviewDisplay/constants';
 import DataOverviewError from '../../../../internal/DataOverviewError/DataOverviewError';
 import { BASE_CLASS, NET_PAYOUT_CLASS } from './constants';
 import { PaginationProps, WithPaginationLimitSelection } from '../../../../internal/Pagination/types';
@@ -101,15 +101,7 @@ export const PayoutsTable: FC<PayoutsTableProps> = ({
                 customCells={{
                     createdAt: ({ value }) => {
                         if (!value) return null;
-                        if (!isSmAndUpViewport)
-                            return dateFormat(value, {
-                                month: 'short',
-                                day: 'numeric',
-                                year: undefined,
-                                hour: '2-digit',
-                                minute: '2-digit',
-                                hour12: false,
-                            });
+                        if (!isSmAndUpViewport) return dateFormat(value, DATE_FORMAT_MOBILE_PAYOUTS);
                         return value && dateFormat(value, DATE_FORMAT_PAYOUTS);
                     },
                     fundsCapturedAmount: ({ value }) => {

--- a/src/components/external/TransactionsOverview/components/TransactionsTable/TransactionsTable.tsx
+++ b/src/components/external/TransactionsOverview/components/TransactionsTable/TransactionsTable.tsx
@@ -1,4 +1,4 @@
-import { DATE_FORMAT_TRANSACTIONS } from '../../../../internal/DataOverviewDisplay/constants';
+import { DATE_FORMAT_MOBILE_TRANSACTIONS, DATE_FORMAT_TRANSACTIONS } from '../../../../internal/DataOverviewDisplay/constants';
 import Category from '../Category/Category';
 import DataOverviewError from '../../../../internal/DataOverviewError/DataOverviewError';
 import { getLabel } from '../../../../utils/getLabel';
@@ -36,7 +36,7 @@ export const TransactionsTable: FC<TransactionTableProps> = ({
     ...paginationProps
 }) => {
     const { i18n } = useCoreContext();
-    const { dateFormat, fullDateFormat } = useTimezoneAwareDateFormatting(activeBalanceAccount?.timeZone);
+    const { dateFormat } = useTimezoneAwareDateFormatting(activeBalanceAccount?.timeZone);
     const [hoveredRow, setHoveredRow] = useState<undefined | number>();
     const isSmAndUpViewport = useResponsiveViewport(mediaQueries.up.sm);
     const isMdAndUpViewport = useResponsiveViewport(mediaQueries.up.md);
@@ -115,7 +115,7 @@ export const TransactionsTable: FC<TransactionTableProps> = ({
                         return (
                             <div className={DATE_AND_PAYMENT_METHOD_CLASS}>
                                 <PaymentMethodCell paymentMethod={item.paymentMethod} bankAccount={item.bankAccount} />
-                                <span className={DATE_AND_PAYMENT_METHOD_CLASS}>{dateFormat(item.createdAt, DATE_FORMAT_TRANSACTIONS)}</span>
+                                <span className={DATE_AND_PAYMENT_METHOD_CLASS}>{dateFormat(item.createdAt, DATE_FORMAT_MOBILE_TRANSACTIONS)}</span>
                             </div>
                         );
                     },
@@ -129,7 +129,7 @@ export const TransactionsTable: FC<TransactionTableProps> = ({
                             )
                         ) : null;
                     },
-                    createdAt: ({ value }) => <span>{fullDateFormat(value)}</span>,
+                    createdAt: ({ value }) => <span>{dateFormat(value, DATE_FORMAT_TRANSACTIONS)}</span>,
                     amount: ({ value }) => {
                         const amount = i18n.amount(value.value, value.currency, { hideCurrency: !hasMultipleCurrencies });
                         return <span className={AMOUNT_CLASS}>{amount}</span>;

--- a/src/components/internal/DataOverviewDisplay/constants.ts
+++ b/src/components/internal/DataOverviewDisplay/constants.ts
@@ -1,30 +1,48 @@
-export const DATE_FORMAT_TRANSACTIONS: Intl.DateTimeFormatOptions = {
-    month: 'short',
-    day: 'numeric',
-    year: undefined,
-    hour: '2-digit',
-    minute: '2-digit',
+const DIGIT_2 = '2-digit';
+const NUMERIC = 'numeric';
+const SHORT = 'short';
+const LONG = 'long';
+
+const BASE_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+    month: LONG,
+    day: NUMERIC,
+    year: NUMERIC,
+};
+
+const BASE_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+    hour: DIGIT_2,
+    minute: DIGIT_2,
+};
+
+const BASE_DATE_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+    ...BASE_DATE_FORMAT,
+    ...BASE_TIME_FORMAT,
+    month: SHORT,
     hour12: false,
 };
 
-export const DATE_FORMAT_TRANSACTION_DETAILS: Intl.DateTimeFormatOptions = {
-    weekday: 'long',
-    month: 'long',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZoneName: 'shortOffset',
-};
+export const DATE_FORMAT_PAYOUTS: Intl.DateTimeFormatOptions = BASE_DATE_FORMAT;
 
-export const DATE_FORMAT_PAYOUTS: Intl.DateTimeFormatOptions = {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
+export const DATE_FORMAT_MOBILE_PAYOUTS: Intl.DateTimeFormatOptions = {
+    ...BASE_DATE_TIME_FORMAT,
+    year: undefined,
 };
 
 export const DATE_FORMAT_PAYOUTS_DETAILS: Intl.DateTimeFormatOptions = {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
+    ...BASE_DATE_FORMAT,
+    weekday: LONG,
+};
+
+export const DATE_FORMAT_TRANSACTIONS: Intl.DateTimeFormatOptions = BASE_DATE_TIME_FORMAT;
+
+export const DATE_FORMAT_MOBILE_TRANSACTIONS: Intl.DateTimeFormatOptions = {
+    ...BASE_DATE_TIME_FORMAT,
+    year: undefined,
+};
+
+export const DATE_FORMAT_TRANSACTION_DETAILS: Intl.DateTimeFormatOptions = {
+    ...BASE_DATE_FORMAT,
+    ...BASE_TIME_FORMAT,
+    weekday: LONG,
+    timeZoneName: 'shortOffset',
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR removes seconds from all dates displayed in the `TransactionsOverview` table for large viewports.

**Fixed issue: [PIE-267: Remove seconds from date in the list](https://youtrack.is.adyen.com/issue/PIE-267/Remove-seconds-from-date-in-the-list)**
