### PR TITLE
Remove page number

### DIFF
--- a/src/components/internal/Pagination/Pagination.tsx
+++ b/src/components/internal/Pagination/Pagination.tsx
@@ -30,9 +30,7 @@ export default function Pagination({ next, hasNext, hasPrev, page, prev, limit, 
     return (
         <div aria-label={i18n.get('paginatedNavigation')} className={`adyen-pe-pagination ${classnames({})}`}>
             <div className="adyen-pe-pagination__context">
-                <span>
-                    {i18n.get('pagination.showing')} {page}
-                </span>
+                <span>{i18n.get('pagination.showing')}</span>
                 {_limitOptions && onLimitSelection && (
                     <div className="adyen-pe-pagination__limit-selector">
                         <Select


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR removes page number from the pagination status information strip as prescribed by the current state of the design.

**Fixed issue: [PIE-420: Change the label on pagination from Page to Showing](https://youtrack.is.adyen.com/issue/PIE-420/Change-the-label-on-pagination-from-Page-to-Showing)**
