### PR TITLE
Refactor Alert and use AlertIcon component

### DIFF
--- a/src/components/external/ReportsOverview/components/ReportsTable/ReportsTable.tsx
+++ b/src/components/external/ReportsOverview/components/ReportsTable/ReportsTable.tsx
@@ -117,9 +117,7 @@ export const ReportsTable: FC<ReportsTableProps> = ({
 
     return (
         <div className={BASE_CLASS}>
-            {alert && (
-                <Alert isOpen={!!alert} onClose={removeAlert} type={AlertTypeOption.WARNING} className={'adyen-pe-reports-table-alert'} {...alert} />
-            )}
+            {alert && <Alert onClose={removeAlert} type={AlertTypeOption.WARNING} className={'adyen-pe-reports-table-alert'} {...alert} />}
             <DataGrid
                 errorDisplay={errorDisplay}
                 error={error}

--- a/src/components/internal/Alert/Alert.scss
+++ b/src/components/internal/Alert/Alert.scss
@@ -3,25 +3,19 @@
 .adyen-pe-alert {
     $adyen-pe-alert: &;
     $adyen-pe-types-list: success, highlight, warning, critical;
-
+    align-items: flex-start;
+    border-radius: style.token(border-radius-m);
     box-sizing: border-box;
     container-type: inline-size;
     display: flex;
+    gap: style.token(spacer-070);
     max-width: 700px;
+    padding: style.token(spacer-070);
     width: 100%;
 
-    &__inner-container {
-        align-items: flex-start;
-        border-radius: style.token(border-radius-m);
-        display: flex;
-        gap: style.token(spacer-070);
-        padding: style.token(spacer-070);
-        width: 100%;
-
-        @container (min-width: 460px) {
-            gap: style.token(spacer-080);
-            padding: style.token(spacer-080);
-        }
+    @container (min-width: 460px) {
+        gap: style.token(spacer-080);
+        padding: style.token(spacer-080);
     }
 
     &__icon {
@@ -31,7 +25,6 @@
     }
 
     &__content {
-        max-width: 500px;
         width: 100%;
     }
 
@@ -41,12 +34,6 @@
 
     &__description:not(:first-child) {
         margin-top: style.token(spacer-020);
-    }
-
-    &__actions {
-        display: flex;
-        gap: style.token(spacer-070);
-        margin-top: style.token(spacer-050);
     }
 
     &__close-button {

--- a/src/components/internal/Alert/Alert.tsx
+++ b/src/components/internal/Alert/Alert.tsx
@@ -1,55 +1,37 @@
 import cx from 'classnames';
 import Button from '../Button';
 import { ButtonVariant } from '../Button/types';
-import Close from '../SVGIcons/Close';
-import WarningFilled from '../SVGIcons/WarningFilled';
 import { TypographyElement, TypographyVariant } from '../Typography/types';
 import Typography from '../Typography/Typography';
 import { AlertProps } from './types';
 import './Alert.scss';
+import Icon from '../Icon';
+import { AlertIcon } from './AlertIcon';
 
-function Alert({ className, description, title, type, onClose, isOpen }: AlertProps) {
-    return (
-        <>
-            {isOpen && (
-                <div className={cx('adyen-pe-alert', className)} role={'alert'}>
-                    <div className={`adyen-pe-alert__inner-container adyen-pe-alert--${type}`}>
-                        <div className={'adyen-pe-alert__icon'}>
-                            <WarningFilled />
-                        </div>
-                        <div className={'adyen-pe-alert__content'}>
-                            {title && (
-                                <Typography
-                                    className={'adyen-pe-alert__title'}
-                                    el={TypographyElement.DIV}
-                                    variant={TypographyVariant.BODY}
-                                    wide
-                                    strongest
-                                >
-                                    {title}
-                                </Typography>
-                            )}
-                            {description && (
-                                <Typography
-                                    className={'adyen-pe-alert__description'}
-                                    el={TypographyElement.DIV}
-                                    variant={TypographyVariant.BODY}
-                                    wide
-                                >
-                                    {description}
-                                </Typography>
-                            )}
-                        </div>
-                        <div className="adyen-pe-alert__close-button">
-                            <Button iconButton variant={ButtonVariant.TERTIARY} onClick={onClose}>
-                                <Close width={7.12} height={7.12} />
-                            </Button>
-                        </div>
-                    </div>
-                </div>
+export const Alert = ({ className, description, title, type, children, onClose }: AlertProps) => (
+    <div className={cx('adyen-pe-alert', `adyen-pe-alert--${type}`, className)} role="alert">
+        <AlertIcon type={type} className="adyen-pe-alert__icon" />
+        <div className={'adyen-pe-alert__content'}>
+            {title && (
+                <Typography className={'adyen-pe-alert__title'} el={TypographyElement.DIV} variant={TypographyVariant.BODY} wide strongest>
+                    {title}
+                </Typography>
             )}
-        </>
-    );
-}
+            {description && (
+                <Typography className={'adyen-pe-alert__description'} el={TypographyElement.DIV} variant={TypographyVariant.BODY} wide>
+                    {description}
+                </Typography>
+            )}
+            {children}
+        </div>
+        {onClose && (
+            <div className="adyen-pe-alert__close-button">
+                <Button iconButton variant={ButtonVariant.TERTIARY} onClick={onClose}>
+                    <Icon name="cross" />
+                </Button>
+            </div>
+        )}
+    </div>
+);
 
 export default Alert;

--- a/src/components/internal/Alert/AlertIcon.tsx
+++ b/src/components/internal/Alert/AlertIcon.tsx
@@ -1,0 +1,21 @@
+import Icon from '../Icon';
+import { AlertTypeOption } from './types';
+
+export interface AlertIconProps {
+    type: AlertTypeOption;
+    className?: string;
+}
+
+export const AlertIcon = ({ className, type }: AlertIconProps) => {
+    switch (type) {
+        case 'warning':
+            return <Icon name="warning" className={className} />;
+        case 'critical':
+            return <Icon name="cross-circle-fill" className={className} />;
+        case 'highlight':
+            return <Icon name="info-filled" className={className} />;
+        case 'success':
+        default:
+            return <Icon name="checkmark-circle-fill" className={className} />;
+    }
+};

--- a/src/components/internal/Alert/types.ts
+++ b/src/components/internal/Alert/types.ts
@@ -1,4 +1,4 @@
-import { VNode } from 'preact';
+import { ComponentChild, VNode } from 'preact';
 import { JSXInternal } from 'preact/src/jsx';
 
 export interface AlertProps {
@@ -6,8 +6,8 @@ export interface AlertProps {
     type: AlertTypeOption;
     title?: VNode<Element> | string;
     description?: VNode<Element> | string;
-    isOpen: boolean;
-    onClose: (event: JSXInternal.TargetedMouseEvent<HTMLButtonElement>) => void;
+    children?: ComponentChild;
+    onClose?: (event: JSXInternal.TargetedMouseEvent<HTMLButtonElement>) => void;
 }
 
 export enum AlertTypeOption {

--- a/src/components/internal/Icon/Icon.scss
+++ b/src/components/internal/Icon/Icon.scss
@@ -1,6 +1,6 @@
 .adyen-pe-icon {
     color: inherit;
-    display: inline-block;
+    display: inherit;
     vertical-align: baseline;
 
     svg {

--- a/src/components/internal/Icon/Icon.tsx
+++ b/src/components/internal/Icon/Icon.tsx
@@ -58,11 +58,12 @@ export const Icon = ({ className, name, ...props }: IconProps) => {
         }
     }, [name]);
 
-
-    return IconComponent && (
-        <span className={cx('adyen-pe-icon', className)} role="img" aria-hidden {...props}>
-            {IconComponent}
-        </span>
+    return (
+        IconComponent && (
+            <span className={cx('adyen-pe-icon', className)} role="img" aria-hidden {...props}>
+                {IconComponent}
+            </span>
+        )
     );
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

* Refactor Alert component
* Add `children` prop
* Remove `isOpen` prop
* Simplify markup
* Add `AlertIcon` component
* Fix usage of `Alert` in codebase



**Fixed issue**:  [CXP-967](https://youtrack.is.adyen.com/issue/CXP-967) Introduce Alert component
