### PR TITLE
Support normal flow for expandable cards

### DIFF
--- a/src/components/internal/ExpandableCard/ExpandableCard.scss
+++ b/src/components/internal/ExpandableCard/ExpandableCard.scss
@@ -30,6 +30,11 @@
             position: absolute;
             top: 0;
             z-index: 100;
+
+            &#{$adyen-pe-expandable-card}__container--in-flow[aria-expanded='true'] {
+                margin-top: calc(var(--adyen-pe-expandable-card-height, 0) * -1);
+                position: relative;
+            }
         }
 
         &--hidden {

--- a/src/components/internal/ExpandableCard/constants.ts
+++ b/src/components/internal/ExpandableCard/constants.ts
@@ -1,10 +1,23 @@
-export const BASE_CLASS = 'adyen-pe-expandable-card';
+const NAMESPACE = 'adyen-pe-expandable-card';
+
+// Block classes
+export const BASE_CLASS = NAMESPACE;
+
+// Element classes
 export const CONTAINER_CLASS = BASE_CLASS + '__container';
+export const CONTENT_CLASS = BASE_CLASS + '__content';
+export const CHEVRON_CLASS = BASE_CLASS + '__chevron';
+
+// Modifier classes
 export const CONTAINER_BUTTON_CLASS = CONTAINER_CLASS + '--button';
 export const CONTAINER_FILLED_CLASS = CONTAINER_CLASS + '--filled';
 export const CONTAINER_HIDDEN_CLASS = CONTAINER_CLASS + '--hidden';
+export const CONTAINER_IN_FLOW_CLASS = CONTAINER_CLASS + '--in-flow';
 export const CONTAINER_OVERLAY_CLASS = CONTAINER_CLASS + '--overlay';
-export const CONTAINER_OVERLAY_ID = CONTAINER_OVERLAY_CLASS;
-export const CONTENT_CLASS = BASE_CLASS + '__content';
 export const CONTENT_EXPANDABLE_CLASS = CONTENT_CLASS + '--expandable';
-export const CHEVRON_CLASS = BASE_CLASS + '__chevron';
+
+// Custom properties
+export const CARD_HEIGHT_PROPERTY = `--${NAMESPACE}-height`;
+
+// Other constants
+export const CONTAINER_OVERLAY_ID = CONTAINER_OVERLAY_CLASS;

--- a/src/components/internal/ExpandableCard/types.ts
+++ b/src/components/internal/ExpandableCard/types.ts
@@ -4,6 +4,7 @@ export interface ExpandableCardProps {
     renderHeader: ComponentChild;
     filled?: boolean;
     fullWidth?: boolean;
+    inFlow?: boolean;
     onMouseEnter?: () => void;
     onFocus?: () => void;
     onMouseLeave?: () => void;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces some updates to the `<ExpandableCard />` component to support rendering the overlayed content in normal flow (when expanded). Prior to this PR, the overlayed content of expandable cards were always rendered out-of-flow when their expandable card is in the expanded state.

By setting the optional `inFlow` prop as `true` on the `<ExpandableCard />` component, its overlayed content will now be rendered in normal flow. The changes are fully backwards-compatible thus, omitting the `inFlow` prop preserves the current behavior.
