### PR TITLE
Disable funds request button after successful endpoint call

### DIFF
--- a/src/components/external/CapitalOffer/components/CapitalOfferSummary/CapitalOfferSummary.tsx
+++ b/src/components/external/CapitalOffer/components/CapitalOfferSummary/CapitalOfferSummary.tsx
@@ -222,7 +222,7 @@ export const CapitalOfferSummary = ({
                     variant={ButtonVariant.PRIMARY}
                     state={requestFundsMutation.isLoading ? 'loading' : undefined}
                     onClick={onRequestFundsHandler}
-                    disabled={requestFundsMutation.isLoading || !!requestFundsMutation.error}
+                    disabled={requestFundsMutation.isLoading || !!requestFundsMutation.error || !!requestFundsMutation.data}
                 >
                     {i18n.get(requestFundsMutation.isLoading ? 'capital.requesting' : 'capital.requestFunds')}
                 </Button>

--- a/tests/integration/components/capitalOffer/default.spec.ts
+++ b/tests/integration/components/capitalOffer/default.spec.ts
@@ -82,6 +82,13 @@ test.describe('Default', () => {
         await page.getByRole('button', { name: 'Back' }).click();
         await expect(page.getByText('Business financing offer')).toBeVisible();
     });
+
+    test('should disable "Request funds" button after funds request call succeeds', async ({ page }) => {
+        await page.getByRole('button', { name: 'Review offer' }).click();
+        const requestFundsButton = page.getByRole('button', { name: 'Request funds' });
+        await requestFundsButton.click();
+        await expect(requestFundsButton).toBeDisabled();
+    });
 });
 
 test.describe('onOfferDismiss argument', () => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Disables "Request funds" button after funds request call succeeds 

**Fixed issue**:  [CXP-3176](https://youtrack.is.adyen.com/issue/CXP-3176) "Request funds" button not disabled after successful funds request call
