### PR TITLE
Mock endpoint for applicable dispute defense documents

### DIFF
--- a/mocks/mock-data/disputes.ts
+++ b/mocks/mock-data/disputes.ts
@@ -499,76 +499,82 @@ export const getApplicableDisputeDefenseDocuments = (dispute: (typeof DISPUTES)[
                 switch (disputeDefenseReason) {
                     case 'AirlineFlightProvided':
                         return [
-                            { type: 'FlightTicketUsed', requirement: 'one_or_more' } as const,
-                            { type: 'FlightTookPlace', requirement: 'one_or_more' } as const,
-                            { type: 'PaperAirlineTicket', requirement: 'one_or_more' } as const,
+                            { documentTypeCode: 'FlightTicketUsed', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'FlightTookPlace', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'PaperAirlineTicket', requirementLevel: 'ONE_OR_MORE' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'CancellationOrReturns':
                         return [
-                            { type: 'CancellationNeverAccepted', requirement: 'one_or_more' } as const,
-                            { type: 'GoodsNotReturned', requirement: 'one_or_more' } as const,
+                            { documentTypeCode: 'CancellationNeverAccepted', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'GoodsNotReturned', requirementLevel: 'ONE_OR_MORE' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'CancellationTermsFailed':
                     case 'InvalidChargebackBundling':
                     case 'NotRecurring':
                     case 'ServicesProvidedAfterCancellation':
-                        return [{ type: 'InvalidChargeback', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [{ documentTypeCode: 'InvalidChargeback', requirementLevel: 'REQUIRED' } as const] satisfies IDisputeDefenseDocument[];
 
                     case 'CreditOrCancellationPolicyProperlyDisclosed':
-                        return [{ type: 'DisclosureAtPointOfInteraction', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [
+                            { documentTypeCode: 'DisclosureAtPointOfInteraction', requirementLevel: 'REQUIRED' } as const,
+                        ] satisfies IDisputeDefenseDocument[];
 
                     case 'GoodsNotReturned':
                         return [
-                            { type: 'GoodsNotReturned', requirement: 'required' } as const,
-                            { type: 'TIDorInvoice', requirement: 'optional' } as const,
+                            { documentTypeCode: 'GoodsNotReturned', requirementLevel: 'REQUIRED' } as const,
+                            { documentTypeCode: 'TIDorInvoice', requirementLevel: 'OPTIONAL' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'GoodsOrServicesProvided':
                         return [
-                            { type: 'ProofOfAbilityToProvideServices', requirement: 'one_or_more' } as const,
-                            { type: 'ProofOfGoodsOrServicesProvided', requirement: 'one_or_more' } as const,
+                            { documentTypeCode: 'ProofOfAbilityToProvideServices', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'ProofOfGoodsOrServicesProvided', requirementLevel: 'ONE_OR_MORE' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'GoodsRepairedOrReplaced':
                         return [
-                            { type: 'GoodsRepairedOrReplaced', requirement: 'required' } as const,
-                            { type: 'TIDorInvoice', requirement: 'optional' } as const,
+                            { documentTypeCode: 'GoodsRepairedOrReplaced', requirementLevel: 'REQUIRED' } as const,
+                            { documentTypeCode: 'TIDorInvoice', requirementLevel: 'OPTIONAL' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'GoodsWereAsDescribed':
                         return [
-                            { type: 'GoodsWereAsDescribed', requirement: 'required' } as const,
-                            { type: 'TIDorInvoice', requirement: 'required' } as const,
+                            { documentTypeCode: 'GoodsWereAsDescribed', requirementLevel: 'REQUIRED' } as const,
+                            { documentTypeCode: 'TIDorInvoice', requirementLevel: 'REQUIRED' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'InvalidChargeback':
-                        return [{ type: 'InvalidChargeback', requirement: 'optional' } as const] satisfies IDisputeDefenseDocument[];
+                        return [{ documentTypeCode: 'InvalidChargeback', requirementLevel: 'OPTIONAL' } as const] satisfies IDisputeDefenseDocument[];
 
                     case 'PaymentByOtherMeans':
-                        return [{ type: 'PaymentByOtherMeans', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [
+                            { documentTypeCode: 'PaymentByOtherMeans', requirementLevel: 'REQUIRED' } as const,
+                        ] satisfies IDisputeDefenseDocument[];
 
                     case 'PurchaseProperlyPosted':
-                        return [{ type: 'ProofOfRetailSaleRatherThanCredit', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [
+                            { documentTypeCode: 'ProofOfRetailSaleRatherThanCredit', requirementLevel: 'REQUIRED' } as const,
+                        ] satisfies IDisputeDefenseDocument[];
 
                     case 'SupplyDefenseMaterial':
                         return [
-                            { type: 'DefenseMaterial', requirement: 'required' } as const,
-                            { type: 'TIDorInvoice', requirement: 'optional' } as const,
+                            { documentTypeCode: 'DefenseMaterial', requirementLevel: 'REQUIRED' } as const,
+                            { documentTypeCode: 'TIDorInvoice', requirementLevel: 'OPTIONAL' } as const,
                         ] satisfies IDisputeDefenseDocument[];
                 }
             } else if (dispute.reasonGroup === 'fraudulent') {
                 switch (disputeDefenseReason) {
                     case 'AirlineCompellingEvidence':
                         return [
-                            { type: 'CompellingEvidence', requirement: 'required' } as const,
-                            { type: 'AdditionalTransactions', requirement: 'one_or_more' } as const,
-                            { type: 'FlightManifest', requirement: 'one_or_more' } as const,
-                            { type: 'FlightTicket', requirement: 'one_or_more' } as const,
-                            { type: 'FlightTicketAtBillingAddress', requirement: 'one_or_more' } as const,
-                            { type: 'FrequentFlyer', requirement: 'one_or_more' } as const,
-                            { type: 'PassengerIdentification', requirement: 'one_or_more' } as const,
+                            { documentTypeCode: 'CompellingEvidence', requirementLevel: 'REQUIRED' } as const,
+                            { documentTypeCode: 'AdditionalTransactions', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'FlightManifest', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'FlightTicket', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'FlightTicketAtBillingAddress', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'FrequentFlyer', requirementLevel: 'ONE_OR_MORE' } as const,
+                            { documentTypeCode: 'PassengerIdentification', requirementLevel: 'ONE_OR_MORE' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'ChipAndPinLiabilityShift':
@@ -577,41 +583,49 @@ export const getApplicableDisputeDefenseDocuments = (dispute: (typeof DISPUTES)[
                     case 'ProofOfCardPresenceAndSignatureChipNoPIN':
                     case 'ProofOfCardPresenceAndSignatureNotMasterCardWorldWideNetwork':
                     case 'ProofOfCardPresenceAndSignatureWithTerminalReceipt':
-                        return [{ type: 'PrintedSignedTerminalReceipt', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [
+                            { documentTypeCode: 'PrintedSignedTerminalReceipt', requirementLevel: 'REQUIRED' } as const,
+                        ] satisfies IDisputeDefenseDocument[];
 
                     case 'CompellingEvidence':
-                        return [{ type: 'CardholderIdentification', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [
+                            { documentTypeCode: 'CardholderIdentification', requirementLevel: 'REQUIRED' } as const,
+                        ] satisfies IDisputeDefenseDocument[];
 
                     case 'IdentifiedAddendum':
-                        return [{ type: 'AddendumDocumentation', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [
+                            { documentTypeCode: 'AddendumDocumentation', requirementLevel: 'REQUIRED' } as const,
+                        ] satisfies IDisputeDefenseDocument[];
 
                     case 'InvalidChargeback':
-                        return [{ type: 'InvalidChargeback', requirement: 'optional' } as const] satisfies IDisputeDefenseDocument[];
+                        return [{ documentTypeCode: 'InvalidChargeback', requirementLevel: 'OPTIONAL' } as const] satisfies IDisputeDefenseDocument[];
 
                     case 'InvalidChargebackBundling':
-                        return [{ type: 'InvalidChargeback', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [{ documentTypeCode: 'InvalidChargeback', requirementLevel: 'REQUIRED' } as const] satisfies IDisputeDefenseDocument[];
 
                     case 'NoShowTransaction':
-                        return [{ type: 'ProofOfNoShow', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [{ documentTypeCode: 'ProofOfNoShow', requirementLevel: 'REQUIRED' } as const] satisfies IDisputeDefenseDocument[];
 
                     case 'RecurringTransactionsCompellingEvidence':
-                        return [{ type: 'CompellingEvidence', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [
+                            { documentTypeCode: 'CompellingEvidence', requirementLevel: 'REQUIRED' } as const,
+                        ] satisfies IDisputeDefenseDocument[];
 
                     case 'RecurringTransactionsCompellingMerchantEvidence':
                         return [
-                            { type: 'MerchantProofOfRecurringTransaction', requirement: 'optional' } as const,
+                            { documentTypeCode: 'MerchantProofOfRecurringTransaction', requirementLevel: 'OPTIONAL' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'ShippedToAVS':
                         return [
-                            { type: 'PositiveAVS', requirement: 'required' } as const,
-                            { type: 'ShippedToAVS', requirement: 'required' } as const,
+                            { documentTypeCode: 'PositiveAVS', requirementLevel: 'REQUIRED' } as const,
+                            { documentTypeCode: 'ShippedToAVS', requirementLevel: 'REQUIRED' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'SupplyDefenseMaterial':
                         return [
-                            { type: 'DefenseMaterial', requirement: 'required' } as const,
-                            { type: 'TIDorInvoice', requirement: 'optional' } as const,
+                            { documentTypeCode: 'DefenseMaterial', requirementLevel: 'REQUIRED' } as const,
+                            { documentTypeCode: 'TIDorInvoice', requirementLevel: 'OPTIONAL' } as const,
                         ] satisfies IDisputeDefenseDocument[];
                 }
             }
@@ -623,21 +637,23 @@ export const getApplicableDisputeDefenseDocuments = (dispute: (typeof DISPUTES)[
             if (dispute.reasonGroup === 'consumer') {
                 switch (disputeDefenseReason) {
                     case 'InvalidChargeback':
-                        return [{ type: 'InvalidChargeback', requirement: 'optional' } as const] satisfies IDisputeDefenseDocument[];
+                        return [{ documentTypeCode: 'InvalidChargeback', requirementLevel: 'OPTIONAL' } as const] satisfies IDisputeDefenseDocument[];
 
                     case 'MerchandiseReceived':
                         return [
-                            { type: 'DateMerchandiseShipped', requirement: 'required' } as const,
-                            { type: 'ProofOfGoodsOrServicesProvided', requirement: 'required' } as const,
+                            { documentTypeCode: 'DateMerchandiseShipped', requirementLevel: 'REQUIRED' } as const,
+                            { documentTypeCode: 'ProofOfGoodsOrServicesProvided', requirementLevel: 'REQUIRED' } as const,
                         ] satisfies IDisputeDefenseDocument[];
 
                     case 'ServicesProvided':
-                        return [{ type: 'ProofOfGoodsOrServicesProvided', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [
+                            { documentTypeCode: 'ProofOfGoodsOrServicesProvided', requirementLevel: 'REQUIRED' } as const,
+                        ] satisfies IDisputeDefenseDocument[];
                 }
             } else if (dispute.reasonGroup === 'fraudulent') {
                 switch (disputeDefenseReason) {
                     case 'AdditionalInformation':
-                        return [{ type: 'DefenseMaterial', requirement: 'required' } as const] satisfies IDisputeDefenseDocument[];
+                        return [{ documentTypeCode: 'DefenseMaterial', requirementLevel: 'REQUIRED' } as const] satisfies IDisputeDefenseDocument[];
                 }
             }
 
@@ -658,18 +674,11 @@ export const getAdditionalDisputeDetails = (dispute: (typeof DISPUTES)[number]) 
     if (dispute.status === 'action_needed') {
         additionalDisputeDetails.defensibility = allowedDefenseReasons ? 'defendable' : 'defendable_externally';
     } else {
-        const lastDefenseReason = allowedDefenseReasons?.[Number(dispute.id.slice(-2)) % allowedDefenseReasons?.length!];
-
         additionalDisputeDetails.defensibility = 'not_defendable';
-
         additionalDisputeDetails.latestDefense = {
+            reason: 'ServicesProvided',
+            suppliedDocuments: ['GoodsOrServicesProvided', 'WrittenRebuttal'],
             defendedOn: getDate(1, new Date(dispute.createdAt)),
-            ...(lastDefenseReason && {
-                reason: lastDefenseReason,
-                suppliedDocuments: (getApplicableDisputeDefenseDocuments(dispute, lastDefenseReason) ?? [])
-                    .filter(({ requirement }) => requirement === 'required')
-                    .map(({ type }) => type),
-            }),
         };
     }
 

--- a/mocks/mock-server/disputes.ts
+++ b/mocks/mock-server/disputes.ts
@@ -91,16 +91,16 @@ export const disputesMocks = [
 
             // Some defense reasons require that at least one of certain types of documents be provided
             // Initially check to see if the current defense reason is one of such
-            let missingOneOrMoreDocuments = defenseDocuments.some(({ requirement }) => requirement === 'one_or_more');
+            let missingOneOrMoreDocuments = defenseDocuments.some(({ requirementLevel }) => requirementLevel === 'ONE_OR_MORE');
 
             for (const applicableDocument of defenseDocuments) {
                 // Check through the applicable defense documents
-                const file = formData.get(applicableDocument.type);
+                const file = formData.get(applicableDocument.documentTypeCode);
 
                 if (file instanceof File) {
                     // A file was uploaded for the corresponding form data field
 
-                    if (applicableDocument.requirement === 'one_or_more') {
+                    if (applicableDocument.requirementLevel === 'ONE_OR_MORE') {
                         // Since a file has been uploaded for at least one of some expected types of documents,
                         // mark as no longer missing the expected documents
                         missingOneOrMoreDocuments = false;
@@ -110,10 +110,10 @@ export const disputesMocks = [
                     continue;
                 }
 
-                if (applicableDocument.requirement === 'required') {
+                if (applicableDocument.requirementLevel === 'REQUIRED') {
                     // No file was uploaded for the corresponding form data field
                     // Since this document is required (this is definitely a bad request)
-                    return HttpResponse.json({ error: `Missing ${applicableDocument.type} document` }, { status: 400 });
+                    return HttpResponse.json({ error: `Missing ${applicableDocument.documentTypeCode} document` }, { status: 400 });
                 }
             }
 

--- a/src/types/api/resources/DisputesResource.ts
+++ b/src/types/api/resources/DisputesResource.ts
@@ -31,10 +31,10 @@ export type webhooks = Record<string, never>;
 
 export interface components {
     schemas: {
-        ApplicableDefenseDocumentRequirement: 'one_or_more' | 'required' | 'optional';
+        ApplicableDefenseDocumentRequirementLevel: 'OPTIONAL' | 'ONE_OR_MORE' | 'REQUIRED';
         ApplicableDefenseDocument: {
-            type: string;
-            requirement: components['schemas']['ApplicableDefenseDocumentRequirement'];
+            documentTypeCode: string;
+            requirementLevel: components['schemas']['ApplicableDefenseDocumentRequirementLevel'];
         };
         Amount: {
             /** @description The three-character [ISO currency code](https://docs.adyen.com/development-resources/currency-codes#currency-codes). */


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces additional mock data and modifications to the mock server endpoint for getting the applicable dispute defense documents. It also introduces modifications to other endpoints that rely on the defense documents data.

**Fixed issue: [CXP-3486: Mock endpoint to get the applicable defense documents](https://youtrack.is.adyen.com/issue/CXP-3486)**
