### PR TITLE
Introduce tab navigation after dispute defense

### DIFF
--- a/src/components/external/CapitalOverview/components/GrantList/GrantsDisplay.tsx
+++ b/src/components/external/CapitalOverview/components/GrantList/GrantsDisplay.tsx
@@ -111,7 +111,7 @@ export const GrantsDisplay: FunctionalComponent<GrantsProps> = ({ grantList, hid
                             id: 'inactive',
                         },
                     ]}
-                    defaultItem={'active'}
+                    activeItem={'active'}
                 />
             )}
         </div>

--- a/src/components/external/DisputesOverview/components/DisputeManagementModal/DisputeManagementModal.tsx
+++ b/src/components/external/DisputesOverview/components/DisputeManagementModal/DisputeManagementModal.tsx
@@ -1,18 +1,21 @@
-import { useCallback, useEffect } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 import { FC, PropsWithChildren } from 'preact/compat';
 import Modal from '../../../../internal/Modal';
 import { DisputeDetailsCustomization } from '../../../DisputeManagement';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { popoverUtil } from '../../../../internal/Popover/utils/popoverUtil';
 import useModalDetails from '../../../../../hooks/useModalDetails';
+import { IDisputeStatusGroup } from '../../../../../types/api/models/disputes';
 import { DisputeDetailsContainer } from '../../../DisputeManagement/components/DisputeDetailsContainer/DisputeDetailsContainer';
 import './DisputeManagementModal.scss';
 
 export interface DisputeManagementModalProps {
+    updateDisputesListStatusGroup: (statusGroup?: IDisputeStatusGroup) => void;
     selectedDetail: ReturnType<typeof useModalDetails>['selectedDetail'];
     resetDetails: ReturnType<typeof useModalDetails>['resetDetails'];
     dataCustomization?: { details: DisputeDetailsCustomization };
     onAcceptDispute?: () => void;
+    onDefendDispute?: () => void;
 }
 
 export const DisputeManagementModal: FC<DisputeManagementModalProps> = ({
@@ -21,8 +24,11 @@ export const DisputeManagementModal: FC<DisputeManagementModalProps> = ({
     resetDetails,
     dataCustomization,
     onAcceptDispute,
+    onDefendDispute,
+    updateDisputesListStatusGroup,
 }: PropsWithChildren<DisputeManagementModalProps>) => {
     const { i18n } = useCoreContext();
+    const [disputesListStatusGroup, setDisputesListStatusGroup] = useState<IDisputeStatusGroup | undefined>(undefined);
     const isModalOpen = !!selectedDetail;
 
     useEffect(() => {
@@ -32,8 +38,21 @@ export const DisputeManagementModal: FC<DisputeManagementModalProps> = ({
     }, [isModalOpen]);
 
     const onAcceptDisputeCallback = useCallback(() => {
+        // [TODO]: Uncomment the following line on confirmation that accepted disputes get hoisted to top of the list
+        // setDisputesListStatusGroup('ONGOING_AND_CLOSED');
         onAcceptDispute?.();
     }, [onAcceptDispute]);
+
+    const onDefendDisputeCallback = useCallback(() => {
+        setDisputesListStatusGroup('ONGOING_AND_CLOSED');
+        onDefendDispute?.();
+    }, [onDefendDispute]);
+
+    const onCloseCallback = useCallback(() => {
+        updateDisputesListStatusGroup(disputesListStatusGroup);
+        setDisputesListStatusGroup(undefined);
+        resetDetails();
+    }, [disputesListStatusGroup, updateDisputesListStatusGroup, resetDetails]);
 
     return (
         <div>
@@ -42,7 +61,7 @@ export const DisputeManagementModal: FC<DisputeManagementModalProps> = ({
                 <Modal
                     isOpen={!!selectedDetail}
                     aria-label={i18n.get('disputes.disputeManagementTitle')}
-                    onClose={resetDetails}
+                    onClose={onCloseCallback}
                     isDismissible={true}
                     headerWithBorder={false}
                     size={selectedDetail.modalSize || 'large'}
@@ -52,6 +71,7 @@ export const DisputeManagementModal: FC<DisputeManagementModalProps> = ({
                             id={selectedDetail.selection.data}
                             dataCustomization={dataCustomization}
                             onAcceptDispute={onAcceptDisputeCallback}
+                            onDefendDispute={onDefendDisputeCallback}
                             hideTitle
                         />
                     </div>

--- a/src/components/external/DisputesOverview/components/DisputesOverview/DisputesOverview.tsx
+++ b/src/components/external/DisputesOverview/components/DisputesOverview/DisputesOverview.tsx
@@ -179,7 +179,7 @@ export const DisputesOverview = ({
                 <FilterBarMobileSwitch {...filterBarState} />
             </Header>
 
-            <Tabs tabs={DISPUTE_STATUS_GROUPS_TABS} defaultActiveTab={DEFAULT_DISPUTE_STATUS_GROUP} onChange={onStatusGroupChange} />
+            <Tabs tabs={DISPUTE_STATUS_GROUPS_TABS} activeTab={DEFAULT_DISPUTE_STATUS_GROUP} onChange={onStatusGroupChange} />
 
             <FilterBar {...filterBarState}>
                 <BalanceAccountSelector

--- a/src/components/external/DisputesOverview/components/DisputesOverview/DisputesOverview.tsx
+++ b/src/components/external/DisputesOverview/components/DisputesOverview/DisputesOverview.tsx
@@ -33,6 +33,7 @@ type DisputeReason = keyof typeof DISPUTE_REASON_CATEGORIES;
 
 const DISPUTE_SCHEMES_FILTER_VALUES = Object.keys(DISPUTE_PAYMENT_SCHEMES) as DisputeScheme[];
 const DISPUTE_REASONS_FILTER_VALUES = Object.keys(DISPUTE_REASON_CATEGORIES) as DisputeReason[];
+const DISPUTE_STATUS_GROUPS_VALUES = Object.keys(DISPUTE_STATUS_GROUPS) as IDisputeStatusGroup[];
 
 const DISPUTE_STATUS_GROUPS_TABS = Object.entries(DISPUTE_STATUS_GROUPS).map(([statusGroup, labelTranslationKey]) => ({
     id: statusGroup as IDisputeStatusGroup,
@@ -61,6 +62,7 @@ export const DisputesOverview = ({
     const { defaultParams, nowTimestamp, refreshNowTimestamp } = useDefaultOverviewFilterParams('disputes', activeBalanceAccount);
 
     const [statusGroup, setStatusGroup] = useState<IDisputeStatusGroup>(DEFAULT_DISPUTE_STATUS_GROUP);
+    const [statusGroupActiveTab, setStatusGroupActiveTab] = useState<IDisputeStatusGroup | undefined>(statusGroup);
     const [statusGroupFetchPending, setStatusGroupFetchPending] = useState(false);
 
     const disputeDetails = useMemo(
@@ -165,9 +167,16 @@ export const DisputesOverview = ({
             }, 500);
 
             setStatusGroup(statusGroup);
+            setStatusGroupActiveTab(undefined);
             setStatusGroupFetchPending(true);
         };
     }, [updateFilters]);
+
+    const updateDisputesListStatusGroup = useCallback((statusGroup?: IDisputeStatusGroup) => {
+        setStatusGroupActiveTab(currentStatusGroupActiveTab =>
+            statusGroup ? (DISPUTE_STATUS_GROUPS_VALUES.includes(statusGroup) ? statusGroup : currentStatusGroupActiveTab) : undefined
+        );
+    }, []);
 
     useEffect(() => {
         refreshNowTimestamp();
@@ -179,7 +188,7 @@ export const DisputesOverview = ({
                 <FilterBarMobileSwitch {...filterBarState} />
             </Header>
 
-            <Tabs tabs={DISPUTE_STATUS_GROUPS_TABS} activeTab={DEFAULT_DISPUTE_STATUS_GROUP} onChange={onStatusGroupChange} />
+            <Tabs tabs={DISPUTE_STATUS_GROUPS_TABS} activeTab={statusGroupActiveTab} onChange={onStatusGroupChange} />
 
             <FilterBar {...filterBarState}>
                 <BalanceAccountSelector
@@ -206,6 +215,7 @@ export const DisputesOverview = ({
                 selectedDetail={selectedDetail as ReturnType<typeof useModalDetails>['selectedDetail']}
                 resetDetails={resetDetails}
                 onAcceptDispute={onAcceptDispute}
+                updateDisputesListStatusGroup={updateDisputesListStatusGroup}
             >
                 <DisputesTable
                     activeBalanceAccount={activeBalanceAccount}

--- a/src/components/internal/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/internal/SegmentedControl/SegmentedControl.tsx
@@ -5,8 +5,8 @@ import useTabbedControl from '../../../hooks/useTabbedControl';
 import Typography from '../Typography/Typography';
 import './SegmentedControl.scss';
 
-function SegmentedControl<ItemId extends string>({ defaultItem, items, onChange }: SegmentedControlProps<ItemId>) {
-    const { activeIndex, onClick, onKeyDown, refs, uniqueId } = useTabbedControl({ onChange, options: items, defaultOption: defaultItem });
+function SegmentedControl<ItemId extends string>({ activeItem, items, onChange }: SegmentedControlProps<ItemId>) {
+    const { activeIndex, onClick, onKeyDown, refs, uniqueId } = useTabbedControl({ onChange, options: items, activeOption: activeItem });
     const { i18n } = useCoreContext();
     return (
         <div>

--- a/src/components/internal/SegmentedControl/types.ts
+++ b/src/components/internal/SegmentedControl/types.ts
@@ -10,6 +10,6 @@ export interface SegmentedControlItem<ItemId extends string> {
 
 export interface SegmentedControlProps<ItemId extends string> {
     onChange?: <ActiveItem extends SegmentedControlItem<ItemId>>(activeItem: ActiveItem) => void;
-    defaultItem?: ItemId;
     items: readonly SegmentedControlItem<ItemId>[];
+    activeItem?: ItemId;
 }

--- a/src/components/internal/Tabs/Tabs.tsx
+++ b/src/components/internal/Tabs/Tabs.tsx
@@ -5,8 +5,8 @@ import useTabbedControl from '../../../hooks/useTabbedControl';
 import Typography from '../Typography/Typography';
 import './Tabs.scss';
 
-function Tabs<TabId extends string>({ defaultActiveTab, tabs, onChange }: TabComponentProps<TabId>) {
-    const { activeIndex, onClick, onKeyDown, refs, uniqueId } = useTabbedControl({ onChange, options: tabs, defaultOption: defaultActiveTab });
+function Tabs<TabId extends string>({ activeTab, tabs, onChange }: TabComponentProps<TabId>) {
+    const { activeIndex, onClick, onKeyDown, refs, uniqueId } = useTabbedControl({ onChange, options: tabs, activeOption: activeTab });
     const { i18n } = useCoreContext();
     return (
         <section aria-label={i18n.get('tabs')}>

--- a/src/components/internal/Tabs/types.ts
+++ b/src/components/internal/Tabs/types.ts
@@ -10,6 +10,6 @@ export type TabProps<TabId extends string> = {
 
 export type TabComponentProps<TabId extends string> = {
     onChange?: <ActiveTab extends TabProps<TabId>>(activeTab: ActiveTab) => void;
-    defaultActiveTab?: TabId;
     tabs: readonly TabProps<TabId>[];
+    activeTab?: TabId;
 };

--- a/src/hooks/useTabbedControl.test.tsx
+++ b/src/hooks/useTabbedControl.test.tsx
@@ -37,11 +37,11 @@ describe('useTabbedControl', () => {
         expect(result.activeIndex).toBe(0);
 
         for (let i = 0; i < OPTIONS.length; i++) {
-            result = getHookResult({ options: OPTIONS, defaultOption: OPTIONS[i]!.id });
+            result = getHookResult({ options: OPTIONS, activeOption: OPTIONS[i]!.id });
             expect(result.activeIndex).toBe(i);
         }
 
-        result = getHookResult({ options: [], defaultOption: 'unknown_option' });
+        result = getHookResult({ options: [], activeOption: 'unknown_option' });
         expect(result.activeIndex).toBe(0);
     });
 
@@ -125,7 +125,7 @@ describe('useTabbedControl', () => {
         const lastOption = OPTIONS[OPTIONS.length - 1];
         const onChange = vi.fn();
 
-        render(<TestComponent options={OPTIONS} defaultOption={lastOption?.id} onChange={onChange} />);
+        render(<TestComponent options={OPTIONS} activeOption={lastOption?.id} onChange={onChange} />);
 
         const optionButtons = screen.getAllByRole('button');
 
@@ -142,7 +142,7 @@ describe('useTabbedControl', () => {
 
         let clickOptionIndex = 1;
 
-        const { rerender } = render(<TestComponent options={OPTIONS} defaultOption={lastOption?.id} onChange={onChange} />);
+        const { rerender } = render(<TestComponent options={OPTIONS} activeOption={lastOption?.id} onChange={onChange} />);
 
         expect(onChange).not.toHaveBeenCalled();
 
@@ -155,7 +155,7 @@ describe('useTabbedControl', () => {
 
         clickOptionIndex = 0;
 
-        rerender(<TestComponent options={OPTIONS} defaultOption={lastOption?.id} onChange={onChange2} />);
+        rerender(<TestComponent options={OPTIONS} activeOption={lastOption?.id} onChange={onChange2} />);
 
         expect(onChange2).not.toHaveBeenCalled();
 

--- a/src/hooks/useTabbedControl.ts
+++ b/src/hooks/useTabbedControl.ts
@@ -6,7 +6,7 @@ export type TabbedControlOptions<OptionId extends string> = readonly { id: Optio
 
 export interface TabbedControlConfig<OptionId extends string, Options extends TabbedControlOptions<OptionId>> {
     onChange?: <ActiveOption extends Options[number]>(activeOption: ActiveOption) => void;
-    defaultOption?: OptionId;
+    activeOption?: OptionId;
     options: Options;
 }
 
@@ -15,22 +15,22 @@ const enum TabDirection {
     FORWARD = 1,
 }
 
-const findDefaultOptionIndex = <OptionId extends string, Options extends TabbedControlOptions<OptionId>>(
+const findActiveOptionIndex = <OptionId extends string, Options extends TabbedControlOptions<OptionId>>(
     options: TabbedControlConfig<OptionId, Options>['options'],
-    defaultOption?: TabbedControlConfig<OptionId, Options>['defaultOption']
+    activeOption?: TabbedControlConfig<OptionId, Options>['activeOption']
 ) => {
-    if (!defaultOption) return 0;
-    const defaultOptionIndex = options.findIndex(option => option.id === defaultOption);
-    return defaultOptionIndex === -1 ? 0 : defaultOptionIndex;
+    if (!activeOption) return 0;
+    const activeOptionIndex = options.findIndex(option => option.id === activeOption);
+    return activeOptionIndex === -1 ? 0 : activeOptionIndex;
 };
 
 export const useTabbedControl = <OptionId extends string, Options extends TabbedControlOptions<OptionId>>({
     options,
-    defaultOption,
+    activeOption: activeOptionFromProps,
     onChange,
 }: TabbedControlConfig<OptionId, Options>) => {
     const [focusPending, setFocusPending] = useState(false);
-    const [activeIndex, setActiveIndex] = useState(findDefaultOptionIndex(options, defaultOption));
+    const [activeIndex, setActiveIndex] = useState(findActiveOptionIndex(options, activeOptionFromProps));
     const optionElementsRef = useRef<(HTMLButtonElement | null)[]>([]);
     const uniqueId = useRef(_uniqueId().replace(/.*?(?=\d+$)/, '')).current;
 
@@ -50,7 +50,7 @@ export const useTabbedControl = <OptionId extends string, Options extends Tabbed
         (index: number, direction: TabDirection) => {
             let currentIndex = index;
             do {
-                if (currentIndex < 0) currentIndex += numberOfOptions;
+                while (currentIndex < 0) currentIndex += numberOfOptions;
                 if (currentIndex >= numberOfOptions) currentIndex %= numberOfOptions;
                 if (optionElementsRef.current[currentIndex]?.disabled === false) break;
             } while ((currentIndex += direction) !== index);

--- a/src/hooks/useTabbedControl.ts
+++ b/src/hooks/useTabbedControl.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { InteractionKeyCode } from '../components/types';
 import { uniqueId as _uniqueId } from '../utils';
 
-export type TabbedControlOptions<OptionId extends string> = readonly { id: OptionId }[];
+export type TabbedControlOptions<OptionId extends string> = readonly { id: OptionId; disabled?: boolean }[];
 
 export interface TabbedControlConfig<OptionId extends string, Options extends TabbedControlOptions<OptionId>> {
     onChange?: <ActiveOption extends Options[number]>(activeOption: ActiveOption) => void;
@@ -15,13 +15,42 @@ const enum TabDirection {
     FORWARD = 1,
 }
 
+const isDisabledOption = <Option extends { disabled?: boolean } | null>(option?: Option) => option?.disabled === true;
+
+const getNearestActiveOptionIndex = <Options extends readonly ({ disabled?: boolean } | null)[]>(
+    options: Options,
+    index: number,
+    direction: TabDirection
+) => {
+    const numberOfOptions = options.length;
+
+    if (numberOfOptions) {
+        let nearestIndex = index;
+        let unvisitedOptions = numberOfOptions;
+
+        while (unvisitedOptions--) {
+            while (nearestIndex < 0) nearestIndex += numberOfOptions;
+            if (nearestIndex >= numberOfOptions) nearestIndex %= numberOfOptions;
+            if (!isDisabledOption(options[nearestIndex])) return nearestIndex;
+            nearestIndex += direction;
+        }
+    }
+
+    return 0;
+};
+
 const findActiveOptionIndex = <OptionId extends string, Options extends TabbedControlOptions<OptionId>>(
     options: TabbedControlConfig<OptionId, Options>['options'],
-    activeOption?: TabbedControlConfig<OptionId, Options>['activeOption']
+    activeOption?: TabbedControlConfig<OptionId, Options>['activeOption'],
+    fallbackActiveOptionIndex = 0
 ) => {
-    if (!activeOption) return 0;
-    const activeOptionIndex = options.findIndex(option => option.id === activeOption);
-    return activeOptionIndex === -1 ? 0 : activeOptionIndex;
+    if (!activeOption) return fallbackActiveOptionIndex;
+
+    const index = options.findIndex(option => option.id === activeOption);
+    const activeOptionIndex = index === -1 ? fallbackActiveOptionIndex : index;
+    const nearestActiveOptionIndex = getNearestActiveOptionIndex(options, activeOptionIndex, TabDirection.FORWARD);
+
+    return activeOptionIndex === nearestActiveOptionIndex ? activeOptionIndex : fallbackActiveOptionIndex;
 };
 
 export const useTabbedControl = <OptionId extends string, Options extends TabbedControlOptions<OptionId>>({
@@ -31,39 +60,24 @@ export const useTabbedControl = <OptionId extends string, Options extends Tabbed
 }: TabbedControlConfig<OptionId, Options>) => {
     const [focusPending, setFocusPending] = useState(false);
     const [activeIndex, setActiveIndex] = useState(findActiveOptionIndex(options, activeOptionFromProps));
-    const optionElementsRef = useRef<(HTMLButtonElement | null)[]>([]);
-    const uniqueId = useRef(_uniqueId().replace(/.*?(?=\d+$)/, '')).current;
 
     const activeOption: Options[number] = options[activeIndex]!;
     const activeOptionRef = useRef(activeOption);
-    const numberOfOptions = options.length;
+    const optionElementsRef = useRef<(HTMLButtonElement | null)[]>([]);
+    const uniqueId = useRef(_uniqueId().replace(/.*?(?=\d+$)/, '')).current;
 
     const refs = useMemo(() => {
         const refs = [] as ((el: HTMLButtonElement | null) => any)[];
-        for (let i = 0; i < numberOfOptions; i++) {
+        for (let i = 0; i < options.length; i++) {
             refs[i] = el => (optionElementsRef.current[i] = el);
         }
         return refs;
-    }, [numberOfOptions]);
-
-    const getNearestActiveIndex = useCallback(
-        (index: number, direction: TabDirection) => {
-            let currentIndex = index;
-            do {
-                while (currentIndex < 0) currentIndex += numberOfOptions;
-                if (currentIndex >= numberOfOptions) currentIndex %= numberOfOptions;
-                if (optionElementsRef.current[currentIndex]?.disabled === false) break;
-            } while ((currentIndex += direction) !== index);
-
-            return currentIndex;
-        },
-        [numberOfOptions]
-    );
+    }, [options]);
 
     const onClick = useCallback((event: MouseEvent) => {
         const clickedOptionIndex = optionElementsRef.current.findIndex(elem => elem === event.currentTarget);
 
-        if (optionElementsRef.current[clickedOptionIndex]?.disabled === false) {
+        if (!isDisabledOption(optionElementsRef.current[clickedOptionIndex])) {
             event.preventDefault();
             setActiveIndex(clickedOptionIndex);
         }
@@ -71,10 +85,12 @@ export const useTabbedControl = <OptionId extends string, Options extends Tabbed
 
     const onKeyDown = useMemo(() => {
         const keyMap: Record<KeyboardEvent['key'], () => void> = {
-            [InteractionKeyCode.ARROW_LEFT]: () => setActiveIndex(activeIndex => getNearestActiveIndex(activeIndex - 1, TabDirection.BACKWARD)),
-            [InteractionKeyCode.ARROW_RIGHT]: () => setActiveIndex(activeIndex => getNearestActiveIndex(activeIndex + 1, TabDirection.FORWARD)),
-            [InteractionKeyCode.HOME]: () => setActiveIndex(getNearestActiveIndex(0, TabDirection.FORWARD)),
-            [InteractionKeyCode.END]: () => setActiveIndex(getNearestActiveIndex(numberOfOptions - 1, TabDirection.BACKWARD)),
+            [InteractionKeyCode.ARROW_LEFT]: () =>
+                setActiveIndex(activeIndex => getNearestActiveOptionIndex(optionElementsRef.current, activeIndex - 1, TabDirection.BACKWARD)),
+            [InteractionKeyCode.ARROW_RIGHT]: () =>
+                setActiveIndex(activeIndex => getNearestActiveOptionIndex(optionElementsRef.current, activeIndex + 1, TabDirection.FORWARD)),
+            [InteractionKeyCode.HOME]: () => setActiveIndex(getNearestActiveOptionIndex(optionElementsRef.current, 0, TabDirection.FORWARD)),
+            [InteractionKeyCode.END]: () => setActiveIndex(getNearestActiveOptionIndex(optionElementsRef.current, -1, TabDirection.BACKWARD)),
         };
 
         return (event: KeyboardEvent) => {
@@ -84,12 +100,16 @@ export const useTabbedControl = <OptionId extends string, Options extends Tabbed
                 setFocusPending(true);
             }
         };
-    }, [numberOfOptions]);
+    }, []);
+
+    useEffect(() => {
+        setActiveIndex(activeIndex => findActiveOptionIndex(options, activeOptionFromProps, activeIndex));
+    }, [options, activeOptionFromProps]);
 
     useEffect(() => {
         if (focusPending) {
             const optionElement = optionElementsRef.current[activeIndex];
-            if (optionElement?.disabled === false) optionElement?.focus();
+            if (!isDisabledOption(optionElement)) optionElement?.focus();
             setFocusPending(false);
         }
     }, [activeIndex, focusPending]);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces some changes to allow for disputes list tab navigation when the disputes management modal is closed after dispute has been successfully defended (or accepted).

To achieve this, these internal changes were introduced to the behavior of tabbed controls:
- Switch from default option prop to active option prop
- Update active option state when the active option prop changes

**Fixed issue: [CXP-3648: Introduce tab navigation after dispute defense](https://youtrack.is.adyen.com/issue/CXP-3648)**
