### PR TITLE
Balance account description and id on separate lines

### DIFF
--- a/src/components/internal/FormFields/Select/BalanceAccountSelector/BalanceAccountSelector.scss
+++ b/src/components/internal/FormFields/Select/BalanceAccountSelector/BalanceAccountSelector.scss
@@ -12,7 +12,7 @@ $adyen-pe-body-line-height: style.token(text-body-line-height);
 
     .adyen-pe-dropdown__element-content {
         display: flex;
-        flex-wrap: wrap;
+        flex-direction: column;
     }
 
     .adyen-pe-dropdown__element-checkmark {
@@ -33,7 +33,6 @@ $adyen-pe-body-line-height: style.token(text-body-line-height);
     }
 
     &__account-label {
-        flex: auto;
         font-weight: style.token(text-body-stronger-font-weight);
         overflow-x: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR fixes an issue with the balance account selector where balance account description and ID are both rendered on the same line for sufficiently wide dropdown menu container.

**Fixed issue: [CXP-3858: FE - Mobile Account filter UI change](https://youtrack.is.adyen.com/issue/CXP-3858)**
