### PR TITLE
Expose environment in core context

### DIFF
--- a/src/components/external/UIElement/UIElement.tsx
+++ b/src/components/external/UIElement/UIElement.tsx
@@ -6,6 +6,7 @@ import { ConfigProvider } from '../../../core/ConfigContext';
 import CoreProvider from '../../../core/Context/CoreProvider';
 import BaseElement from '../BaseElement';
 import './UIElement.scss';
+import { FALLBACK_ENV } from '../../../core/utils';
 
 export class UIElement<P> extends BaseElement<P & UIElementProps> implements IUIElement {
     protected componentRef: UIElement<P> | null = null;
@@ -88,6 +89,7 @@ export class UIElement<P> extends BaseElement<P & UIElementProps> implements IUI
             <ConfigProvider type={this.type} session={core.session} key={performance.now()}>
                 <CoreProvider
                     componentRef={this.compRef}
+                    environment={core.options.environment || FALLBACK_ENV}
                     i18n={core.localization.i18n}
                     getCdnConfig={core.getCdnConfig}
                     getImageAsset={core.getImageAsset}

--- a/src/core/Context/CoreContext.ts
+++ b/src/core/Context/CoreContext.ts
@@ -2,11 +2,13 @@ import { createContext } from 'preact';
 import { noop } from '../../utils';
 import { CommonPropsTypes, CoreProviderProps } from './types';
 import Localization from '../Localization';
+import { FALLBACK_ENV } from '../utils';
 
-export const CoreContext = createContext<CoreProviderProps & { i18n: Localization['i18n'] }>({
+export const CoreContext = createContext<CoreProviderProps>({
     i18n: new Localization().i18n,
     loadingContext: '',
     commonProps: {} as CommonPropsTypes,
     updateCore: noop,
     componentRef: { current: null },
+    environment: FALLBACK_ENV,
 });

--- a/src/core/Context/CoreProvider.tsx
+++ b/src/core/Context/CoreProvider.tsx
@@ -21,6 +21,7 @@ const CoreProvider = ({
     getDatasetAsset,
     getCdnDataset,
     getCdnConfig,
+    environment,
 }: CoreProviderProps) => {
     const [ready, setReady] = useBooleanState(false);
     const commonProps = useMemo(() => _commonProps || {}, [_commonProps]);
@@ -45,6 +46,7 @@ const CoreProvider = ({
             getDatasetAsset,
             getCdnConfig,
             getCdnDataset,
+            environment,
         }),
         [
             commonProps,
@@ -57,6 +59,7 @@ const CoreProvider = ({
             getCdnConfig,
             getCdnDataset,
             updateCore,
+            environment,
         ]
     );
 

--- a/src/core/Context/types.ts
+++ b/src/core/Context/types.ts
@@ -1,5 +1,5 @@
 import Localization from '../Localization';
-import { onErrorHandler } from '../types';
+import { DevEnvironment, onErrorHandler } from '../types';
 import { RefObject } from 'preact';
 import { AssetOptions } from '../Assets/Assets';
 
@@ -10,7 +10,7 @@ export interface CommonPropsTypes {
 export interface CoreProviderProps {
     children?: any;
     commonProps?: CommonPropsTypes;
-    i18n?: Localization['i18n'];
+    i18n: Localization['i18n'];
     loadingContext?: string;
     updateCore?: () => void;
     externalErrorHandler?: onErrorHandler | null;
@@ -19,4 +19,5 @@ export interface CoreProviderProps {
     getDatasetAsset?: (props: AssetOptions) => string;
     getCdnConfig?: <Fallback>(props: { name: string; extension?: string; subFolder?: string; fallback?: Fallback }) => Promise<Fallback>;
     getCdnDataset?: <Fallback>(props: { name: string; extension?: string; subFolder?: string; fallback?: Fallback }) => Promise<Fallback>;
+    environment: DevEnvironment;
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Exposes environment from core so it can be used to initialize onboarding components.
