### PR TITLE
Introduce polling for grant actions

### DIFF
--- a/mocks/mock-server/capital.ts
+++ b/mocks/mock-server/capital.ts
@@ -198,25 +198,51 @@ export const CapitalOverviewMockedResponses = capitalFactory({
         { endpoint: mockEndpoints.grants, response: { data: [PENDING_GRANT_WITH_MULTIPLE_ACTIONS] } },
         { endpoint: mockEndpoints.onboardingConfiguration, response: ONBOARDING_CONFIGURATION },
     ],
+    grantMultipleAsyncActionsEmbedded: (() => {
+        let firstCallTime: number | undefined;
+        return [
+            { endpoint: mockEndpoints.dynamicOfferConfig, handler: EMPTY_OFFER },
+            {
+                endpoint: mockEndpoints.grants,
+                handler: async () => {
+                    if (!firstCallTime) {
+                        firstCallTime = Date.now();
+                    }
+                    const elapsedTime = Date.now() - firstCallTime;
+                    const grant = elapsedTime < 1000 ? PENDING_GRANT_WITH_SINGLE_ACTION : PENDING_GRANT_WITH_MULTIPLE_ACTIONS;
+                    return getHandlerCallback({ response: { data: [grant] }, status: 200 })();
+                },
+            },
+            { endpoint: mockEndpoints.onboardingConfiguration, response: ONBOARDING_CONFIGURATION },
+        ];
+    })(),
     grantMultipleActionsHosted: [
         { endpoint: mockEndpoints.dynamicOfferConfig, handler: EMPTY_OFFER },
         { endpoint: mockEndpoints.grants, response: { data: [PENDING_GRANT_WITH_MULTIPLE_ACTIONS] } },
         { endpoint: mockEndpoints.onboardingConfiguration, handler: getHandlerCallback({ response: undefined, status: 204 }) },
-        {
-            endpoint: mockEndpoints.signToS,
-            handler: async () => {
-                await delay(500);
-                return HttpResponse.json(SIGN_TOS_ACTION_DETAILS, { status: 200 });
-            },
-        },
-        {
-            endpoint: mockEndpoints.anaCredit,
-            handler: async () => {
-                await delay(500);
-                return HttpResponse.json(ANACREDIT_ACTION_DETAILS, { status: 200 });
-            },
-        },
+        { endpoint: mockEndpoints.signToS, handler: getHandlerCallback({ response: SIGN_TOS_ACTION_DETAILS, status: 200 }) },
+        { endpoint: mockEndpoints.anaCredit, handler: getHandlerCallback({ response: ANACREDIT_ACTION_DETAILS, status: 200 }) },
     ],
+    grantMultipleAsyncActionsHosted: (() => {
+        let firstCallTime: number | undefined;
+        return [
+            { endpoint: mockEndpoints.dynamicOfferConfig, handler: EMPTY_OFFER },
+            {
+                endpoint: mockEndpoints.grants,
+                handler: async () => {
+                    if (!firstCallTime) {
+                        firstCallTime = Date.now();
+                    }
+                    const elapsedTime = Date.now() - firstCallTime;
+                    const grant = elapsedTime < 1000 ? PENDING_GRANT_WITH_SINGLE_ACTION : PENDING_GRANT_WITH_MULTIPLE_ACTIONS;
+                    return getHandlerCallback({ response: { data: [grant] }, status: 200 })();
+                },
+            },
+            { endpoint: mockEndpoints.onboardingConfiguration, handler: getHandlerCallback({ response: undefined, status: 204 }) },
+            { endpoint: mockEndpoints.signToS, handler: getHandlerCallback({ response: SIGN_TOS_ACTION_DETAILS, status: 200 }) },
+            { endpoint: mockEndpoints.anaCredit, handler: getHandlerCallback({ response: ANACREDIT_ACTION_DETAILS, status: 200 }) },
+        ];
+    })(),
     grantSingleActionEmbedded: [
         { endpoint: mockEndpoints.dynamicOfferConfig, handler: EMPTY_OFFER },
         { endpoint: mockEndpoints.grants, response: { data: [PENDING_GRANT_WITH_SINGLE_ACTION] } },
@@ -226,13 +252,7 @@ export const CapitalOverviewMockedResponses = capitalFactory({
         { endpoint: mockEndpoints.dynamicOfferConfig, handler: EMPTY_OFFER },
         { endpoint: mockEndpoints.grants, response: { data: [PENDING_GRANT_WITH_SINGLE_ACTION] } },
         { endpoint: mockEndpoints.onboardingConfiguration, handler: getHandlerCallback({ response: undefined, status: 204 }) },
-        {
-            endpoint: mockEndpoints.signToS,
-            handler: async () => {
-                await delay(500);
-                return HttpResponse.json(SIGN_TOS_ACTION_DETAILS, { status: 200 });
-            },
-        },
+        { endpoint: mockEndpoints.signToS, handler: getHandlerCallback({ response: SIGN_TOS_ACTION_DETAILS, status: 200 }) },
     ],
     grantActive: [
         { endpoint: mockEndpoints.dynamicOfferConfig, response: EMPTY_OFFER },

--- a/src/components/external/CapitalOverview/components/GrantActions/GrantActions.tsx
+++ b/src/components/external/CapitalOverview/components/GrantActions/GrantActions.tsx
@@ -9,6 +9,7 @@ import { GrantActionsHosted } from '../GrantActionsHosted/GrantActionsHosted';
 import { AlertTypeOption } from '../../../../internal/Alert/types';
 import Alert from '../../../../internal/Alert/Alert';
 import './GrantActions.scss';
+import { useMissingActionsPolling } from './hooks';
 
 const CLASSNAMES = {
     actionsTitleSkeleton: 'adyen-pe-grant-actions__actions-title-skeleton',
@@ -16,17 +17,25 @@ const CLASSNAMES = {
 };
 
 type GrantActionsProps = {
+    grantId: string;
     missingActions: IMissingAction[];
     offerExpiresAt?: string;
     className?: string;
     onComplete: () => void;
 };
 
-export const GrantActions: FunctionalComponent<GrantActionsProps> = ({ missingActions = [], offerExpiresAt, className, onComplete }) => {
+export const GrantActions: FunctionalComponent<GrantActionsProps> = ({
+    grantId,
+    missingActions: initialMissingActions,
+    offerExpiresAt,
+    className,
+    onComplete,
+}) => {
     const { getOnboardingConfiguration } = useConfigContext().endpoints;
+    const { missingActions, isPollingComplete } = useMissingActionsPolling({ grantId, initialMissingActions });
 
     const onboardingConfigurationQuery = useFetch({
-        fetchOptions: { enabled: !!missingActions.length },
+        fetchOptions: { enabled: isPollingComplete && !!missingActions.length },
         queryFn: useCallback(async () => {
             return getOnboardingConfiguration?.(EMPTY_OBJECT);
         }, [getOnboardingConfiguration]),
@@ -36,7 +45,7 @@ export const GrantActions: FunctionalComponent<GrantActionsProps> = ({ missingAc
         return null;
     }
 
-    if (onboardingConfigurationQuery.isFetching) {
+    if (!isPollingComplete || onboardingConfigurationQuery.isFetching) {
         return (
             <Alert
                 className={className}

--- a/src/components/external/CapitalOverview/components/GrantActions/hooks.tsx
+++ b/src/components/external/CapitalOverview/components/GrantActions/hooks.tsx
@@ -1,0 +1,54 @@
+import { IGrant, IMissingAction } from '../../../../../types';
+import { useConfigContext } from '../../../../../core/ConfigContext';
+import { useFetch } from '../../../../../hooks/useFetch';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { EMPTY_OBJECT } from '../../../../../utils';
+
+const MAX_POLL_COUNT = 3;
+const POLL_INTERVAL_MS = 1000;
+
+type UseMissingActionsPollingParams = {
+    grantId: string;
+    initialMissingActions: IMissingAction[];
+};
+
+// TODO: Remove this hook when AnaCredit and SignTOS resolve at the same time.
+// Polls for missing actions because AnaCredit resolves slower than SignTOS, allowing both to be rendered together.
+export const useMissingActionsPolling = ({ grantId, initialMissingActions }: UseMissingActionsPollingParams) => {
+    const { getGrants } = useConfigContext().endpoints;
+    const shouldPoll = initialMissingActions.length <= 1;
+    const pollCountRef = useRef(0);
+    const [isPollingComplete, setIsPollingComplete] = useState(!shouldPoll);
+    const [missingActions, setMissingActions] = useState<IMissingAction[]>(initialMissingActions);
+
+    const { data, isFetching, refetch } = useFetch({
+        fetchOptions: {
+            enabled: shouldPoll,
+            onSuccess: useCallback(() => {
+                pollCountRef.current += 1;
+            }, []),
+        },
+        queryFn: useCallback(async () => getGrants?.(EMPTY_OBJECT), [getGrants]),
+    });
+
+    useEffect(() => {
+        if (!shouldPoll || isPollingComplete || isFetching) return;
+
+        const grant = data?.data?.find((grant: IGrant) => grant.id === grantId);
+        const currentMissingActions = grant?.missingActions ?? initialMissingActions;
+        setMissingActions(currentMissingActions);
+
+        if (currentMissingActions.length > 1 || pollCountRef.current >= MAX_POLL_COUNT) {
+            setIsPollingComplete(true);
+            return;
+        }
+
+        const timeoutId = setTimeout(() => {
+            refetch();
+        }, POLL_INTERVAL_MS);
+
+        return () => clearTimeout(timeoutId);
+    }, [data, isFetching, refetch, grantId, isPollingComplete, shouldPoll, initialMissingActions]);
+
+    return { missingActions, isPollingComplete };
+};

--- a/src/components/external/CapitalOverview/components/GrantItem/GrantItem.tsx
+++ b/src/components/external/CapitalOverview/components/GrantItem/GrantItem.tsx
@@ -181,6 +181,7 @@ export const GrantItem: FunctionalComponent<GrantItemProps> = ({ grant, showDeta
                 <>
                     {grant.missingActions && grant.missingActions.length ? (
                         <GrantActions
+                            grantId={grant.id}
                             missingActions={grant.missingActions}
                             className={GRANT_ITEM_CLASS_NAMES.alert}
                             offerExpiresAt={grant.offerExpiresAt}

--- a/stories/mocked/capitalOverview.stories.tsx
+++ b/stories/mocked/capitalOverview.stories.tsx
@@ -110,6 +110,16 @@ export const GrantMultipleActionsEmbedded: ElementStory<typeof CapitalOverview> 
     },
 };
 
+export const GrantMultipleAsyncActionsEmbedded: ElementStory<typeof CapitalOverview> = {
+    name: 'Grant: Multiple async actions - Embedded',
+    args: {
+        mockedApi: true,
+    },
+    parameters: {
+        msw: CapitalOverviewMockedResponses.grantMultipleAsyncActionsEmbedded,
+    },
+};
+
 export const GrantMultipleActionsHosted: ElementStory<typeof CapitalOverview> = {
     name: 'Grant: Multiple actions - Hosted',
     args: {
@@ -117,6 +127,16 @@ export const GrantMultipleActionsHosted: ElementStory<typeof CapitalOverview> = 
     },
     parameters: {
         msw: CapitalOverviewMockedResponses.grantMultipleActionsHosted,
+    },
+};
+
+export const GrantMultipleAsyncActionsHosted: ElementStory<typeof CapitalOverview> = {
+    name: 'Grant: Multiple async actions - Hosted',
+    args: {
+        mockedApi: true,
+    },
+    parameters: {
+        msw: CapitalOverviewMockedResponses.grantMultipleAsyncActionsHosted,
     },
 };
 


### PR DESCRIPTION
For higher grants AnaCredit resolves slower than SignTOS. For a streamlined flow we want the missing actions to be shown at the same time. This PR enables that through polling.

This feature is temporary - at some point BE will ensure the missing actions are resolved at the same time. 