### PR TITLE
Introduce story for onboarding config error

### DIFF
--- a/mocks/mock-server/capital.ts
+++ b/mocks/mock-server/capital.ts
@@ -318,6 +318,14 @@ export const CapitalOverviewMockedResponses = capitalFactory({
         { endpoint: mockEndpoints.dynamicOfferConfig, response: EMPTY_OFFER },
         { endpoint: mockEndpoints.grants, response: { data: GRANTS } },
     ],
+    errorActionsEmbedded: [
+        { endpoint: mockEndpoints.dynamicOfferConfig, handler: EMPTY_OFFER },
+        { endpoint: mockEndpoints.grants, response: { data: [PENDING_GRANT_WITH_SINGLE_ACTION] } },
+        {
+            endpoint: mockEndpoints.onboardingConfiguration,
+            handler: getErrorHandler(new AdyenPlatformExperienceError(ErrorTypes.ERROR, 'Something went wrong', 'Message'), 500),
+        },
+    ],
     errorActionsHosted: [
         { endpoint: mockEndpoints.dynamicOfferConfig, handler: EMPTY_OFFER },
         { endpoint: mockEndpoints.grants, response: { data: [PENDING_GRANT_WITH_SINGLE_ACTION] } },

--- a/stories/mocked/capitalOverview.stories.tsx
+++ b/stories/mocked/capitalOverview.stories.tsx
@@ -294,6 +294,18 @@ export const ErrorDynamicOfferConfigInactiveAccountHolder: ElementStory<typeof C
     },
 };
 
+export const ErrorActionsEmbedded: ElementStory<typeof CapitalOverview> = {
+    name: 'Error - Actions Embedded',
+    args: {
+        mockedApi: true,
+    },
+    parameters: {
+        msw: {
+            handlers: CapitalOverviewMockedResponses.errorActionsEmbedded,
+        },
+    },
+};
+
 export const ErrorActionsHosted: ElementStory<typeof CapitalOverview> = {
     name: 'Error - Actions Hosted',
     args: {

--- a/tests/integration/components/capitalOverview/errorActionsEmbedded.spec.ts
+++ b/tests/integration/components/capitalOverview/errorActionsEmbedded.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '../../../fixtures/analytics/events';
+import { expectAnalyticsEvents, goToStory } from '../../../utils/utils';
+import { sharedGrantsOverviewAnalyticsEventProperties } from './constants/analytics';
+
+const STORY_ID = 'mocked-capital-capital-overview--error-actions-embedded';
+
+test.describe('Error - Actions Embedded', () => {
+    test.beforeEach(async ({ page, analyticsEvents }) => {
+        await goToStory(page, { id: STORY_ID });
+        await expectAnalyticsEvents(analyticsEvents, [['Landed on page', sharedGrantsOverviewAnalyticsEventProperties]]);
+    });
+
+    test('should render pending grant with actions', async ({ page }) => {
+        const actionButton = page.getByRole('button', { name: 'Sign terms & conditions' });
+        await expect(page.getByText('Requested funds')).toBeVisible();
+        await expect(page.getByText('€20,000.00')).toBeVisible();
+        await expect(page.getByText('Action needed')).toBeVisible();
+        await expect(page.getByText('Grant ID')).toBeVisible();
+        await expect(page.getByTestId('grant-id-copy-text')).toBeVisible();
+        await expect(
+            page.getByText('We need a bit more input from you to process your funds. Please complete this action by February 15, 2025.')
+        ).toBeVisible();
+        await expect(actionButton).toBeVisible();
+        await expect(actionButton).toContainClass('adyen-pe-button--tertiary');
+        await expect(page.getByRole('progressbar')).toBeHidden();
+        await expect(page.getByTestId('expand-button')).toBeHidden();
+    });
+});


### PR DESCRIPTION
Adding a story to enable testing the case when the onboarding config cannot be retrieved from BE.