### PR TITLE
fix: eslint testing library

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -68,6 +68,8 @@ module.exports = {
                     'tests/**/*.{ts,js}',
                     'tests/**/**/*.spec.ts',
                     'src/utils/testing/**/*.{ts,tsx}',
+                    'src/**/__testing__/**/*.{ts,tsx}',
+                    'src/**/testing/**/*.{ts,tsx}',
                 ],
                 includeTypes: false,
             },

--- a/src/components/external/PaymentLinkCreation/components/Form/PaymentDetailsForm/Fields/ValidityField.tsx
+++ b/src/components/external/PaymentLinkCreation/components/Form/PaymentDetailsForm/Fields/ValidityField.tsx
@@ -41,7 +41,7 @@ export const ValidityField: FunctionalComponent<ValidityFieldProps> = ({ configu
                 return { id: FLEXIBLE_ID, name: i18n.get('payByLink.creation.fields.validity.linkValidityUnit.custom') };
             }
             const key: TranslationKey = `payByLink.creation.fields.validity.linkValidityUnit.${durationUnit}`;
-            return { id: `${quantity} ${durationUnit}` || '', name: i18n.get(key, { values: { quantity }, count: quantity }) };
+            return { id: `${quantity} ${durationUnit}`, name: i18n.get(key, { values: { quantity }, count: quantity }) };
         });
     }, [configuration, i18n]);
 

--- a/src/components/external/TransactionDetails/components/PaymentDetails/PaymentDetails.tsx
+++ b/src/components/external/TransactionDetails/components/PaymentDetails/PaymentDetails.tsx
@@ -52,7 +52,7 @@ const PaymentDetails = ({
         () =>
             TX_DETAILS_TABS.filter(({ id }) => {
                 switch (id) {
-                    case DetailsTab.SUMMARY:
+                    case DetailsTab.SUMMARY: {
                         const { additions, deductions, originalAmount, amountBeforeDeductions, netAmount } = transaction;
                         return (
                             (additions && additions.length > 0) ||
@@ -60,6 +60,7 @@ const PaymentDetails = ({
                             (originalAmount && originalAmount.value !== amountBeforeDeductions.value) ||
                             netAmount.value !== amountBeforeDeductions.value
                         );
+                    }
                     case DetailsTab.TIMELINE:
                         return transaction.events && transaction.events.length > 0;
                     default:

--- a/src/components/external/TransactionDetails/hooks/useInputNormalizer/useInputNormalizer.ts
+++ b/src/components/external/TransactionDetails/hooks/useInputNormalizer/useInputNormalizer.ts
@@ -14,7 +14,7 @@ export const createInputNormalizer = (maxChars = Infinity) => {
     }
 
     const _extensiveNormalize = (input: string) => {
-        let substringChars = maxChars === Infinity ? input.length : maxChars;
+        const substringChars = maxChars === Infinity ? input.length : maxChars;
         let normalizedChars = 0;
         let normalized = '';
 

--- a/src/components/internal/Calendar/calendar/timeframe/common/utils.ts
+++ b/src/components/internal/Calendar/calendar/timeframe/common/utils.ts
@@ -5,7 +5,9 @@ import { mod } from '../../../../../../utils';
 export const downsizeTimeFrame = (size: TimeFrameSize, maxsize: number): TimeFrameSize => {
     if (maxsize >= size) return size;
     let i = Math.max(1, FRAME_SIZES.indexOf(size));
-    while (--i && maxsize < (FRAME_SIZES[i] as TimeFrameSize)) {}
+    while (--i && maxsize < (FRAME_SIZES[i] as TimeFrameSize)) {
+        /* intentionally empty */
+    }
     return FRAME_SIZES[i] as TimeFrameSize;
 };
 

--- a/src/components/internal/Calendar/calendar/timerange/utils.ts
+++ b/src/components/internal/Calendar/calendar/timerange/utils.ts
@@ -46,6 +46,7 @@ export const getRangeTimestampsContextIntegerPropertyFactory = <T extends number
                 set(this: RangeTimestamps, value?: T | null) {
                     const currentValue = normalizedValue;
                     normalizedValue = _getNormalizedValue(value, normalizedValue);
+                    // eslint-disable-next-line no-self-assign
                     if (currentValue !== normalizedValue) this.now = this.now;
                 },
             }),

--- a/src/components/internal/Calendar/calendar/timeslice/TimeSlice.ts
+++ b/src/components/internal/Calendar/calendar/timeslice/TimeSlice.ts
@@ -13,7 +13,7 @@ export default class __TimeSlice__ {
     constructor(timezone?: string, time?: Time, timeEdge?: TimeFrameRangeEdge);
     constructor(...args: any[]) {
         if (args.length >= 3) {
-            let timestamp = new Date(args[1]).getTime();
+            const timestamp = new Date(args[1]).getTime();
 
             if (typeof args[2] !== 'symbol') {
                 this.#startTimestamp = timestamp || this.#startTimestamp;

--- a/src/components/internal/DataGrid/tests/DataGrid.test.tsx
+++ b/src/components/internal/DataGrid/tests/DataGrid.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, within } from '@testing-library/preact';
-import { describe, test, expect, beforeEach, vi, Mock } from 'vitest';
+import { render, screen, within } from '@testing-library/preact';
+import { describe, test, expect, vi } from 'vitest';
 import { TRANSACTIONS } from '../../../../../mocks/mock-data';
 import userEvent from '@testing-library/user-event';
 import DataGrid from '../../DataGrid';
@@ -22,18 +22,12 @@ const columns = [
     },
 ] satisfies { key: keyof Partial<(typeof TRANSACTIONS)[number]>; label: string }[];
 
-interface DataGridTestContext {
-    screen: any;
-    mockEventHandler: Mock<any>;
-    user: ReturnType<(typeof userEvent)['setup']>;
-    getRow: (index: number) => any;
-}
 describe('DataGrid component with clickable rows', () => {
-    beforeEach<DataGridTestContext>(async context => {
+    const renderDataGrid = () => {
         const mockEventHandler = vi.fn();
         const mockHover = vi.fn();
 
-        const screen = render(
+        render(
             <div>
                 <DataGrid
                     data={TRANSACTIONS}
@@ -62,13 +56,11 @@ describe('DataGrid component with clickable rows', () => {
             return within(within(table).getAllByRole('rowgroup')[1]!).getAllByRole('row')[index];
         };
 
-        context.screen = screen;
-        context.mockEventHandler = mockEventHandler;
-        context.user = user;
-        context.getRow = getRow;
-    });
+        return { mockEventHandler, user, getRow };
+    };
 
-    test<DataGridTestContext>('The rows are focusable', async ({ getRow, user }) => {
+    test('The rows are focusable', async () => {
+        const { getRow, user } = renderDataGrid();
         const firstRow = getRow(0);
 
         expect(document.body).toHaveFocus();
@@ -78,9 +70,10 @@ describe('DataGrid component with clickable rows', () => {
         expect(firstRow).toHaveFocus();
     });
 
-    test<DataGridTestContext>('The list is traversed with the keyboard arrows', async ({ getRow, user }) => {
-        const secondRow = getRow(1);
-        const thirdRow = getRow(2);
+    test('The list is traversed with the keyboard arrows', async () => {
+        const { getRow, user } = renderDataGrid();
+        const secondRow = getRow(1)!;
+        const thirdRow = getRow(2)!;
 
         await user.tab();
 
@@ -106,7 +99,8 @@ describe('DataGrid component with clickable rows', () => {
         expect(secondRow).toHaveFocus();
     });
 
-    test<DataGridTestContext>('The click event is triggered with the ENTER key', async ({ user, mockEventHandler }) => {
+    test('The click event is triggered with the ENTER key', async () => {
+        const { user, mockEventHandler } = renderDataGrid();
         await user.tab();
 
         await user.keyboard('[Enter]');

--- a/src/components/internal/DataOverviewDetails/DataOverviewDetails.tsx
+++ b/src/components/internal/DataOverviewDetails/DataOverviewDetails.tsx
@@ -34,9 +34,10 @@ export default function DataOverviewDetails(props: ExternalUIComponentProps<Deta
                 fetchOptions: { enabled: !!props.id && !!getDetail },
                 queryFn: async () => {
                     switch (props.type) {
-                        case 'payout':
+                        case 'payout': {
                             const queryParam = { query: { balanceAccountId: props.id, createdAt: props.date } };
                             return getDetail!(EMPTY_OBJECT, { ...queryParam });
+                        }
                     }
                 },
             }),

--- a/src/components/internal/ErrorMessageDisplay/ErrorMessageDisplay.test.tsx
+++ b/src/components/internal/ErrorMessageDisplay/ErrorMessageDisplay.test.tsx
@@ -84,20 +84,18 @@ describe('ErrorMessageDisplay', () => {
         });
 
         test('should render with desktop and mobile images', () => {
-            const { container } = render(
-                <ErrorMessageDisplay title={'testTitle' as TranslationKey} imageDesktop="desktop.svg" imageMobile="mobile.svg" />
-            );
+            render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} imageDesktop="desktop.svg" imageMobile="mobile.svg" />);
 
             const image = screen.getByRole('img');
             expect(image).toHaveAttribute('alt', '');
 
             // Verify picture element has correct sources for responsive images
-            const sources = container.querySelectorAll('source');
-            expect(sources).toHaveLength(2);
-            expect(sources[0]).toHaveAttribute('media', `(min-width: ${IMAGE_BREAKPOINT_MEDIUM_PX}px)`);
-            expect(sources[0]).toHaveAttribute('srcSet', 'desktop.svg');
-            expect(sources[1]).toHaveAttribute('media', `(max-width: ${IMAGE_BREAKPOINT_MEDIUM_PX}px)`);
-            expect(sources[1]).toHaveAttribute('srcSet', 'mobile.svg');
+            const sourceDesktop = screen.getByTestId('source-desktop');
+            const sourceMobile = screen.getByTestId('source-mobile');
+            expect(sourceDesktop).toHaveAttribute('media', `(min-width: ${IMAGE_BREAKPOINT_MEDIUM_PX}px)`);
+            expect(sourceDesktop).toHaveAttribute('srcSet', 'desktop.svg');
+            expect(sourceMobile).toHaveAttribute('media', `(max-width: ${IMAGE_BREAKPOINT_MEDIUM_PX}px)`);
+            expect(sourceMobile).toHaveAttribute('srcSet', 'mobile.svg');
         });
 
         test('should render with default image when withImage is true', () => {
@@ -118,34 +116,32 @@ describe('ErrorMessageDisplay', () => {
 
     describe('Conditional Styling', () => {
         test('should apply default styling classes', () => {
-            const { container } = render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} />);
+            render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} />);
 
-            const errorDisplay = container.querySelector('.adyen-pe-error-message-display--absolute-position');
-            const outlined = container.querySelector('.adyen-pe-error-message-display--outlined');
-
-            expect(errorDisplay).toBeInTheDocument();
-            expect(outlined).toBeInTheDocument();
+            const errorDisplay = screen.getByTestId('error-message-display');
+            expect(errorDisplay).toHaveClass('adyen-pe-error-message-display--absolute-position');
+            expect(errorDisplay).toHaveClass('adyen-pe-error-message-display--outlined');
         });
 
         test('should not apply outlined class when outlined is false', () => {
-            const { container } = render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} outlined={false} />);
+            render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} outlined={false} />);
 
-            const errorDisplay = container.querySelector('.adyen-pe-error-message-display--outlined');
-            expect(errorDisplay).not.toBeInTheDocument();
+            const errorDisplay = screen.getByTestId('error-message-display');
+            expect(errorDisplay).not.toHaveClass('adyen-pe-error-message-display--outlined');
         });
 
         test('should apply centered class when centered is true', () => {
-            const { container } = render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} centered={true} />);
+            render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} centered={true} />);
 
-            const errorDisplay = container.querySelector('.adyen-pe-error-message-display--centered');
-            expect(errorDisplay).toBeInTheDocument();
+            const errorDisplay = screen.getByTestId('error-message-display');
+            expect(errorDisplay).toHaveClass('adyen-pe-error-message-display--centered');
         });
 
         test('should apply background class when withBackground is true and outlined is false', () => {
-            const { container } = render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} withBackground={true} outlined={false} />);
+            render(<ErrorMessageDisplay title={'testTitle' as TranslationKey} withBackground={true} outlined={false} />);
 
-            const errorDisplay = container.querySelector('.adyen-pe-error-message-display--with-background');
-            expect(errorDisplay).toBeInTheDocument();
+            const errorDisplay = screen.getByTestId('error-message-display');
+            expect(errorDisplay).toHaveClass('adyen-pe-error-message-display--with-background');
         });
     });
 

--- a/src/components/internal/ErrorMessageDisplay/ErrorMessageDisplay.tsx
+++ b/src/components/internal/ErrorMessageDisplay/ErrorMessageDisplay.tsx
@@ -40,6 +40,7 @@ type ErrorMessageDisplayProps = {
     withBackground?: boolean;
     withHeaderOffset?: boolean;
     condensed?: boolean;
+    testId?: string;
 };
 
 const ErrorMessageSeparator = () => (
@@ -67,6 +68,7 @@ export const ErrorMessageDisplay = ({
     withBackground,
     withHeaderOffset,
     condensed,
+    testId = 'error-message-display',
 }: ErrorMessageDisplayProps) => {
     const { i18n, updateCore, getImageAsset } = useCoreContext();
 
@@ -86,6 +88,7 @@ export const ErrorMessageDisplay = ({
 
     return (
         <div
+            data-testid={testId}
             className={cx(classes.base, {
                 [classes.base_absolutePosition]: absolutePosition,
                 [classes.base_centered]: centered,
@@ -98,8 +101,14 @@ export const ErrorMessageDisplay = ({
             {(imageDesktop || imageMobile || withImage) && (
                 <div className={classes.illustration}>
                     <picture>
-                        <source type="image/svg+xml" media={`(min-width: ${IMAGE_BREAKPOINT_MEDIUM_PX}px)`} srcSet={imageDesktop} />
                         <source
+                            data-testid="source-desktop"
+                            type="image/svg+xml"
+                            media={`(min-width: ${IMAGE_BREAKPOINT_MEDIUM_PX}px)`}
+                            srcSet={imageDesktop}
+                        />
+                        <source
+                            data-testid="source-mobile"
                             type="image/svg+xml"
                             media={`(max-width: ${IMAGE_BREAKPOINT_MEDIUM_PX}px)`}
                             srcSet={imageMobile ?? getImageAsset?.({ name: 'wrong-environment', subFolder: 'images/small' })}

--- a/src/components/internal/ExpandableCard/ExpandableCard.test.tsx
+++ b/src/components/internal/ExpandableCard/ExpandableCard.test.tsx
@@ -2,51 +2,47 @@
  * @vitest-environment jsdom
  */
 import { render, screen, waitFor } from '@testing-library/preact';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import ExpandableCard from './ExpandableCard';
 import { CONTAINER_HIDDEN_CLASS } from './constants';
 
 describe('ExpandableCard component', () => {
-    const testExpandBehaviour = async () => {
-        const expandButton = screen.getByTestId('expand-button');
-        const collapseButton = screen.getByTestId('collapse-button');
-        expandButton.click();
-        await waitFor(() => {
-            expect(collapseButton).not.toHaveClass(CONTAINER_HIDDEN_CLASS);
-            expect(collapseButton).toHaveFocus();
-        });
-        return { expandButton, collapseButton } as const;
-    };
-
-    beforeEach(() => {
+    const renderExpandableCard = () =>
         render(
             <div>
                 <button data-testid="outside-element">{'Click'}</button>
                 <ExpandableCard renderContent="Header">{'Body'}</ExpandableCard>
             </div>
         );
-    });
+
+    const testExpandBehaviour = async () => {
+        const expandButton = screen.getByTestId('expand-button');
+        const collapseButton = screen.getByTestId('collapse-button');
+        expandButton.click();
+        await waitFor(() => expect(collapseButton).not.toHaveClass(CONTAINER_HIDDEN_CLASS));
+        await waitFor(() => expect(collapseButton).toHaveFocus());
+        return { expandButton, collapseButton } as const;
+    };
 
     test('should show and focus collapse button when expand button is clicked', async () => {
+        renderExpandableCard();
         await testExpandBehaviour();
     });
 
     test('should hide collapse button and focus expand button when collapse button is clicked', async () => {
+        renderExpandableCard();
         const { collapseButton, expandButton } = await testExpandBehaviour();
         collapseButton.click();
-        await waitFor(() => {
-            expect(collapseButton).toHaveClass(CONTAINER_HIDDEN_CLASS);
-            expect(expandButton).toHaveFocus();
-        });
+        await waitFor(() => expect(collapseButton).toHaveClass(CONTAINER_HIDDEN_CLASS));
+        await waitFor(() => expect(expandButton).toHaveFocus());
     });
 
     test('should hide collapse button and not focus expand button when clicking outside of the collapse button', async () => {
+        renderExpandableCard();
         const outsideElement = screen.getByTestId('outside-element');
         const { collapseButton, expandButton } = await testExpandBehaviour();
         outsideElement.click();
-        await waitFor(() => {
-            expect(collapseButton).toHaveClass(CONTAINER_HIDDEN_CLASS);
-            expect(expandButton).not.toHaveFocus();
-        });
+        await waitFor(() => expect(collapseButton).toHaveClass(CONTAINER_HIDDEN_CLASS));
+        await waitFor(() => expect(expandButton).not.toHaveFocus());
     });
 });

--- a/src/components/internal/FormFields/CalendarInput/CalendarInput.test.tsx
+++ b/src/components/internal/FormFields/CalendarInput/CalendarInput.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CalendarInput } from './CalendarInput';
 import useCoreContext from '../../../../core/Context/useCoreContext';
@@ -132,23 +132,18 @@ describe('CalendarInput', () => {
         });
     });
 
-    test('should format label correctly with different date values', () => {
-        const testCases = [
-            { value: undefined, expected: 'Select date' },
-            { value: '', expected: 'Select date' },
-            { value: '2023-12-25T10:00:00.000Z', expected: 'Dec 25, 2023' },
-            { value: '2024-01-01T00:00:00.000Z', expected: 'Jan 01, 2024' },
-        ];
+    test.each([
+        { value: undefined, expected: 'Select date' },
+        { value: '', expected: 'Select date' },
+        { value: '2023-12-25T10:00:00.000Z', expected: 'Dec 25, 2023' },
+        { value: '2024-01-01T00:00:00.000Z', expected: 'Jan 01, 2024' },
+    ])('should format label correctly with value $value', ({ value, expected }) => {
+        mockDateFormat.mockReturnValue(expected);
 
-        testCases.forEach(({ value, expected }) => {
-            cleanup();
-            mockDateFormat.mockReturnValue(expected);
+        render(<CalendarInput value={value} onInput={mockOnInput} />);
 
-            render(<CalendarInput value={value} onInput={mockOnInput} />);
-
-            const button = screen.getByRole('button');
-            expect(button).toHaveTextContent(expected);
-        });
+        const button = screen.getByRole('button');
+        expect(button).toHaveTextContent(expected);
     });
 
     test('should apply correct CSS classes', () => {
@@ -193,27 +188,26 @@ describe('CalendarInput', () => {
     test('should show clear button only when clearable and value is provided', () => {
         const testDate = '2023-12-25T10:00:00.000Z';
 
-        const { container, rerender } = render(<CalendarInput value={testDate} onInput={mockOnInput} clearable={true} />);
-        expect(container.querySelector('.adyen-pe-dropdown__button-clear')).toBeInTheDocument();
+        const { rerender } = render(<CalendarInput value={testDate} onInput={mockOnInput} clearable={true} />);
+        expect(screen.getByTestId('calendar-input-clear-button')).toBeInTheDocument();
 
         rerender(<CalendarInput value={testDate} onInput={mockOnInput} clearable={false} />);
-        expect(container.querySelector('.adyen-pe-dropdown__button-clear')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('calendar-input-clear-button')).not.toBeInTheDocument();
 
         rerender(<CalendarInput value={undefined} onInput={mockOnInput} clearable={true} />);
-        expect(container.querySelector('.adyen-pe-dropdown__button-clear')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('calendar-input-clear-button')).not.toBeInTheDocument();
     });
 
     test('should clear value when clear button is clicked and not open the popover', () => {
         const testDate = '2023-12-25T10:00:00.000Z';
-        const { container } = render(<CalendarInput value={testDate} onInput={mockOnInput} clearable={true} />);
+        render(<CalendarInput value={testDate} onInput={mockOnInput} clearable={true} />);
 
         const mainButton = screen.getAllByRole('button')[0];
         expect(mainButton).toHaveAttribute('aria-expanded', 'false');
 
-        const clearButton = container.querySelector('.adyen-pe-dropdown__button-clear');
-        expect(clearButton).toBeInTheDocument();
+        const clearButton = screen.getByTestId('calendar-input-clear-button');
 
-        fireEvent.click(clearButton as Element);
+        fireEvent.click(clearButton);
         expect(mockOnInput).toHaveBeenCalledWith('');
         expect(mainButton).toHaveAttribute('aria-expanded', 'false');
     });

--- a/src/components/internal/FormFields/CalendarInput/components/CalendarInputButton.tsx
+++ b/src/components/internal/FormFields/CalendarInput/components/CalendarInputButton.tsx
@@ -47,6 +47,7 @@ export function CalendarInputButton({
                         <span
                             role="button"
                             tabIndex={0}
+                            data-testid="calendar-input-clear-button"
                             className="adyen-pe-dropdown__button-clear"
                             onClick={e => {
                                 e.preventDefault();

--- a/src/components/internal/FormFields/FileInput/FileInput.test.tsx
+++ b/src/components/internal/FormFields/FileInput/FileInput.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, expect, test, vi } from 'vitest';
-import { act, render, screen, within } from '@testing-library/preact';
+import { render, screen, waitFor, within } from '@testing-library/preact';
 import { userEvent } from '@testing-library/user-event';
 import FileInput from './FileInput';
 
@@ -29,9 +29,7 @@ describe('FileInput', () => {
         const dropzone = screen.getByRole('region');
         const fileInput = within(dropzone).getByTestId('dropzone-input');
 
-        await act(async () => {
-            await user.upload(fileInput, MOCK_FILE);
-        });
+        await user.upload(fileInput, MOCK_FILE);
 
         const fileName = screen.getByText('photo.png');
         const fileSize = screen.getByText(/bytes$/);
@@ -52,24 +50,21 @@ describe('FileInput', () => {
 
         render(<FileInput />);
 
-        await act(async () => {
-            const dropzone = screen.getByRole('region');
-            const fileInput = within(dropzone).getByTestId('dropzone-input');
-            await user.upload(fileInput, MOCK_FILE);
-        });
-
-        const fileDeleteButton = screen.getByRole('button');
-
-        await act(async () => {
-            await user.click(fileDeleteButton);
-        });
-
         const dropzone = screen.getByRole('region');
         const fileInput = within(dropzone).getByTestId('dropzone-input');
 
+        await user.upload(fileInput, MOCK_FILE);
+
+        const fileDeleteButton = screen.getByRole('button');
+
+        await user.click(fileDeleteButton);
+
+        const newDropzone = screen.getByRole('region');
+        const newFileInput = within(newDropzone).getByTestId('dropzone-input');
+
         expect(fileDeleteButton).not.toBeInTheDocument();
 
-        [dropzone, fileInput].forEach(elem => {
+        [newDropzone, newFileInput].forEach(elem => {
             expect(elem).toBeInTheDocument();
             expect(elem).toBeVisible();
         });
@@ -81,20 +76,15 @@ describe('FileInput', () => {
 
         render(<FileInput onChange={onChange} />);
 
-        await act(async () => {
-            const dropzone = screen.getByRole('region');
-            const fileInput = within(dropzone).getByTestId('dropzone-input');
-            await user.upload(fileInput, MOCK_FILE);
-        });
+        const dropzone = screen.getByRole('region');
+        const fileInput = within(dropzone).getByTestId('dropzone-input');
 
-        expect(onChange).toHaveBeenCalledOnce();
+        await user.upload(fileInput, MOCK_FILE);
+        await waitFor(() => expect(onChange).toHaveBeenCalledOnce());
         expect(onChange).toHaveBeenLastCalledWith([MOCK_FILE]);
 
-        await act(async () => {
-            await user.click(screen.getByRole('button'));
-        });
-
-        expect(onChange).toHaveBeenCalledTimes(2);
+        await user.click(screen.getByRole('button'));
+        await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
         expect(onChange).toHaveBeenLastCalledWith([]);
     });
 
@@ -106,13 +96,11 @@ describe('FileInput', () => {
 
         expect(onChange).not.toHaveBeenCalled();
 
-        await act(async () => {
-            const dropzone = screen.getByRole('region');
-            const fileInput = within(dropzone).getByTestId('dropzone-input');
-            await user.upload(fileInput, MOCK_FILE);
-        });
+        const dropzone = screen.getByRole('region');
+        const fileInput = within(dropzone).getByTestId('dropzone-input');
 
-        expect(onChange).toHaveBeenCalledOnce();
+        await user.upload(fileInput, MOCK_FILE);
+        await waitFor(() => expect(onChange).toHaveBeenCalledOnce());
         expect(onChange).toHaveBeenLastCalledWith([MOCK_FILE]);
 
         const onChange2 = vi.fn();
@@ -121,11 +109,8 @@ describe('FileInput', () => {
 
         expect(onChange2).not.toHaveBeenCalled();
 
-        await act(async () => {
-            await user.click(screen.getByRole('button'));
-        });
-
-        expect(onChange2).toHaveBeenCalledOnce();
+        await user.click(screen.getByRole('button'));
+        await waitFor(() => expect(onChange2).toHaveBeenCalledOnce());
         expect(onChange2).toHaveBeenLastCalledWith([]);
     });
 });

--- a/src/components/internal/FormFields/FileInput/components/Dropzone.test.tsx
+++ b/src/components/internal/FormFields/FileInput/components/Dropzone.test.tsx
@@ -22,9 +22,7 @@ describe('Dropzone', () => {
 
         const dropzone = screen.getByRole('region');
         const fileInput: HTMLInputElement = within(dropzone).getByTestId('dropzone-input');
-        const labelElement = within(dropzone)
-            .getByText(/Browse files/)
-            .closest('label')!;
+        const labelElement = within(dropzone).getByTestId('dropzone-label');
 
         [dropzone, fileInput, labelElement].forEach(elem => {
             expect(elem).toBeInTheDocument();
@@ -47,7 +45,7 @@ describe('Dropzone', () => {
 
         const dropzone = screen.getByRole('region');
         const childElement = within(dropzone).getByText(/Choose document/);
-        const labelElement = childElement.closest('label')!;
+        const labelElement = within(dropzone).getByTestId('dropzone-label');
 
         [childElement, labelElement].forEach(elem => {
             expect(elem).toBeInTheDocument();
@@ -201,10 +199,8 @@ describe('Dropzone', () => {
         for (let i = 1; i <= 3; i++) {
             const file = FILES[i % FILES.length]!;
 
-            await act(() => {
-                fireEvent.drop(dropzone, {
-                    dataTransfer: { files: [file] },
-                });
+            fireEvent.drop(dropzone, {
+                dataTransfer: { files: [file] },
             });
 
             await waitFor(() => expect(uploadFilesMock).toHaveBeenCalledTimes(i));
@@ -219,10 +215,8 @@ describe('Dropzone', () => {
 
         const dropzone = screen.getByRole('region');
 
-        await act(() => {
-            fireEvent.drop(dropzone, {
-                dataTransfer: { files: FILES },
-            });
+        fireEvent.drop(dropzone, {
+            dataTransfer: { files: FILES },
         });
 
         expect(uploadFilesMock).not.toHaveBeenCalled();
@@ -240,10 +234,8 @@ describe('Dropzone', () => {
 
         const dropzone = screen.getByRole('region');
 
-        await act(() => {
-            fireEvent.drop(dropzone, {
-                dataTransfer: { files: [DISALLOWED_FILE] },
-            });
+        fireEvent.drop(dropzone, {
+            dataTransfer: { files: [DISALLOWED_FILE] },
         });
 
         expect(uploadFilesMock).not.toHaveBeenCalled();
@@ -263,10 +255,8 @@ describe('Dropzone', () => {
         const dropzone = screen.getByRole('region');
         const file = FILES[0]!;
 
-        await act(() => {
-            fireEvent.drop(dropzone, {
-                dataTransfer: { files: [file] },
-            });
+        fireEvent.drop(dropzone, {
+            dataTransfer: { files: [file] },
         });
 
         expect(uploadFilesMock).not.toHaveBeenCalled();
@@ -285,10 +275,8 @@ describe('Dropzone', () => {
         const dropzone = screen.getByRole('region');
         const file = FILES[0];
 
-        await act(() => {
-            fireEvent.drop(dropzone, {
-                dataTransfer: { files: [file] },
-            });
+        fireEvent.drop(dropzone, {
+            dataTransfer: { files: [file] },
         });
 
         expect(uploadFilesMock).not.toHaveBeenCalled();

--- a/src/components/internal/FormFields/FileInput/components/Dropzone.tsx
+++ b/src/components/internal/FormFields/FileInput/components/Dropzone.tsx
@@ -26,6 +26,26 @@ const classes = {
     errorText: `${BASE_CLASS}__error-text`,
 };
 
+const getImageDimensions = async (file: File): Promise<{ width: number; height: number }> => {
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        const url = URL.createObjectURL(file);
+        const cleanup = () => URL.revokeObjectURL(url);
+
+        image.src = url;
+
+        image.onerror = err => {
+            cleanup();
+            reject(err);
+        };
+
+        image.onload = () => {
+            cleanup();
+            resolve({ width: image.width, height: image.height });
+        };
+    });
+};
+
 export const Dropzone = fixedForwardRef<DropzoneProps, HTMLInputElement>((props, ref) => {
     const {
         id,
@@ -108,18 +128,6 @@ export const Dropzone = fixedForwardRef<DropzoneProps, HTMLInputElement>((props,
         [inputRef]
     );
 
-    const getImageDimensions = async (file: File): Promise<{ width: number; height: number }> => {
-        return new Promise((resolve, reject) => {
-            const image = new Image();
-            const url = URL.createObjectURL(file);
-            image.src = url;
-            image.onerror = reject;
-            image.onload = function () {
-                resolve({ width: image.width, height: image.height });
-            };
-        });
-    };
-
     const updateFiles = useCallback(
         async <T extends UploadedFileSource>(source?: T | null): Promise<void> => {
             const uploadedFiles = getUploadedFilesFromSource(source);
@@ -193,13 +201,13 @@ export const Dropzone = fixedForwardRef<DropzoneProps, HTMLInputElement>((props,
                     onChange={handleFileChange}
                     onInvalid={handleInputInvalid}
                     aria-invalid={isInvalid}
-                    data-testId="dropzone-input"
+                    data-testid="dropzone-input"
                 />
 
                 {/* Using the label element here to expose a user interaction surface for the file input element. */}
                 {/* The input element itself is visually hidden (not visible), but available to assistive technology. */}
                 {/* To preserve proper focus styling, this label element should always come after the input element. */}
-                <label className={classes.label} htmlFor={inputId}>
+                <label data-testid="dropzone-label" className={classes.label} htmlFor={inputId}>
                     {children ?? (
                         <div className={cx(classes.labelDefault)}>
                             {

--- a/src/components/internal/Popover/Popover.test.tsx
+++ b/src/components/internal/Popover/Popover.test.tsx
@@ -6,19 +6,13 @@ import { PopoverContainerPosition, PopoverContainerVariant } from './types';
 import { render, screen, waitFor } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'preact';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import Popover from './Popover';
 
-interface PopoverContext {
-    dismiss: () => any;
-    applyAction: () => any;
-}
-
 describe('Popover component', () => {
-    beforeEach<PopoverContext>(context => {
-        context.dismiss = vi.fn();
-        context.applyAction = vi.fn();
-
+    const renderPopover = (props?: { dismiss?: () => any; applyAction?: () => any }) => {
+        const dismiss = props?.dismiss ?? vi.fn();
+        const applyAction = props?.applyAction ?? vi.fn();
         const buttonEl = createRef();
 
         render(
@@ -31,7 +25,7 @@ describe('Popover component', () => {
                         title={'Test Popover'}
                         open={true}
                         disableFocusTrap={true}
-                        dismiss={context.dismiss}
+                        dismiss={dismiss}
                         dismissible={true}
                         variant={PopoverContainerVariant.TOOLTIP}
                         position={PopoverContainerPosition.BOTTOM}
@@ -39,7 +33,7 @@ describe('Popover component', () => {
                             {
                                 title: 'apply',
                                 variant: ButtonVariant.PRIMARY,
-                                event: context.applyAction,
+                                event: applyAction,
                                 disabled: false,
                             },
                         ]}
@@ -49,18 +43,23 @@ describe('Popover component', () => {
                 )}
             </div>
         );
-    });
+
+        return { dismiss, applyAction };
+    };
 
     test('should automatically focus', async () => {
+        renderPopover();
         const inputEl = screen.getByTestId('mock-textbox');
         await waitFor(() => {
             expect(inputEl).toHaveFocus();
         });
     });
 
-    test<PopoverContext>('should call dismiss on click outside', async ({ dismiss }) => {
+    test('should call dismiss on click outside', async () => {
+        const dismiss = vi.fn();
+        renderPopover({ dismiss });
+
         const titleEl = screen.getByText(/Test Popover/i);
-        const buttonEl = screen.getByRole('button', { name: 'Popover Controller' });
         const outsideEl = screen.getByText('Outside of component');
         const inputEl = screen.getByTestId('mock-textbox');
 
@@ -76,7 +75,10 @@ describe('Popover component', () => {
         expect(dismiss).toBeCalledTimes(1);
     });
 
-    test<PopoverContext>('should call dismiss on esc keyboard action', async ({ dismiss }) => {
+    test('should call dismiss on esc keyboard action', async () => {
+        const dismiss = vi.fn();
+        renderPopover({ dismiss });
+
         await userEvent.keyboard('[Escape]');
         const buttonEl = screen.getByRole('button', { name: 'Popover Controller' });
         const popoverEl = screen.getByTestId('mock-textbox');
@@ -85,7 +87,10 @@ describe('Popover component', () => {
         expect(popoverEl).not.toHaveFocus();
     });
 
-    test<PopoverContext>('should have dismiss icon', async ({ dismiss }) => {
+    test('should have dismiss icon', async () => {
+        const dismiss = vi.fn();
+        renderPopover({ dismiss });
+
         const closeButton = screen.getByLabelText(/close/i);
         expect(closeButton).toBeInTheDocument();
 
@@ -93,7 +98,10 @@ describe('Popover component', () => {
         expect(dismiss).toBeCalledTimes(1);
     });
 
-    test<PopoverContext>('should have action button and call function on click', async ({ applyAction }) => {
+    test('should have action button and call function on click', async () => {
+        const applyAction = vi.fn();
+        renderPopover({ applyAction });
+
         const applyButton = screen.getByLabelText(/apply/i);
         expect(applyButton).toBeInTheDocument();
 
@@ -113,7 +121,7 @@ describe('Popover component', () => {
 });
 
 describe('Popover component close', () => {
-    beforeEach(() => {
+    test('should not appear', () => {
         const buttonEl = createRef();
 
         render(
@@ -124,9 +132,7 @@ describe('Popover component close', () => {
                 </Popover>
             </div>
         );
-    });
 
-    test('should not appear', () => {
         const inputEl = screen.queryByRole('textbox');
         expect(inputEl).not.toBeInTheDocument();
     });

--- a/src/components/internal/StoreSelector/StoreSelector.test.tsx
+++ b/src/components/internal/StoreSelector/StoreSelector.test.tsx
@@ -22,7 +22,7 @@ describe('StoreSelector', () => {
 
     test('should render null when stores array is empty', () => {
         const { container } = render(<StoreSelector stores={[]} selectedStoreId={undefined} setSelectedStoreId={mockSetSelectedStoreId} />);
-        expect(container.firstChild).toBeNull();
+        expect(container).toBeEmptyDOMElement();
     });
 
     test('should not render a button when there is only one store', () => {

--- a/src/components/internal/ToggleSwitch/ToggleSwitch.test.tsx
+++ b/src/components/internal/ToggleSwitch/ToggleSwitch.test.tsx
@@ -94,20 +94,18 @@ describe('ToggleSwitch', () => {
         render(<ToggleSwitch>{'My Label'}</ToggleSwitch>);
 
         const label = screen.getByText('My Label');
-        expect(label).toBeInTheDocument();
-
         const switchEl = screen.getByTestId('toggle-switch-control');
-        expect(switchEl.nextElementSibling).toBe(label);
+        // switchEl precedes label in document order → label is after switch
+        expect(label.compareDocumentPosition(switchEl) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
     });
 
     test('should render the label content before the switch when labelBeforeSwitch is true', () => {
         render(<ToggleSwitch labelBeforeSwitch>{'My Label'}</ToggleSwitch>);
 
         const label = screen.getByText('My Label');
-        expect(label).toBeInTheDocument();
-
         const switchEl = screen.getByTestId('toggle-switch-control');
-        expect(switchEl.previousElementSibling).toBe(label);
+        // switchEl follows label in document order → label is before switch
+        expect(label.compareDocumentPosition(switchEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 
     test('should render JSX content as the label', () => {

--- a/src/core/Http/http.ts
+++ b/src/core/Http/http.ts
@@ -63,7 +63,7 @@ export async function http<T>(options: HttpOptions): Promise<T> {
 
                     //TODO: when backend is ready double check this logic
                     switch (contentType) {
-                        case 'application/json':
+                        case 'application/json': {
                             // This could throw an exception if response body content is not valid JSON
                             const text = await res.clone().text();
                             if (!text) {
@@ -73,10 +73,12 @@ export async function http<T>(options: HttpOptions): Promise<T> {
                                 return null;
                             }
                             return await res.json();
-                        default:
+                        }
+                        default: {
                             const blob = await res.blob();
                             const filename = getResponseDownloadFilename(res);
                             return { blob, filename } as const satisfies EndpointDownloadStreamData;
+                        }
                     }
                 } catch (ex) {
                     // If it does throw an exception, the exception will be propagated to the caller (unhandled).

--- a/src/core/Localization/datetime/restamper/restamper.test.ts
+++ b/src/core/Localization/datetime/restamper/restamper.test.ts
@@ -45,7 +45,7 @@ describe('restamper', () => {
     });
 
     test<RestamperTestContext>('should return restamp result for current time (when argument is omitted)', ({ restamper }) => {
-        let result = restamper();
+        const result = restamper();
 
         expect(result).toHaveProperty('formatted');
         expect(result).toHaveProperty('offset');

--- a/src/hooks/element/useClickOutside.test.tsx
+++ b/src/hooks/element/useClickOutside.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { cleanup, render } from '@testing-library/preact';
+import { render, screen } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import { popoverUtil } from '../../components/internal/Popover/utils/popoverUtil';
 import { ClickOutsideVariant, CONTROL_ELEMENT_PROPERTY, useClickOutside } from './useClickOutside';
@@ -21,8 +21,7 @@ describe('useClickOutside', () => {
     });
 
     afterEach(() => {
-        cleanup();
-        if (outsideDiv && outsideDiv.parentNode) outsideDiv.parentNode.removeChild(outsideDiv);
+        if (outsideDiv) outsideDiv.remove();
         popoverUtil.closeAll();
         vi.restoreAllMocks();
     });
@@ -30,7 +29,7 @@ describe('useClickOutside', () => {
     const TestComponent = ({ cb = callback, disable = false, variant = ClickOutsideVariant.DEFAULT, id = 'target', children = null as any }) => {
         const ref = useClickOutside(null, cb, disable, variant);
         return (
-            <div ref={ref} id={id}>
+            <div ref={ref} id={id} data-testid={id}>
                 {children}
             </div>
         );
@@ -47,8 +46,8 @@ describe('useClickOutside', () => {
 
     test('should not call callback when clicking inside the element', async () => {
         const user = userEvent.setup();
-        const { getByText } = render(<TestComponent>{'Inside'}</TestComponent>);
-        const target = getByText('Inside');
+        render(<TestComponent>{'Inside'}</TestComponent>);
+        const target = screen.getByText('Inside');
 
         await user.click(target);
 
@@ -57,8 +56,8 @@ describe('useClickOutside', () => {
 
     test('should not call callback when dragging from inside to outside', async () => {
         const user = userEvent.setup();
-        const { getByText } = render(<TestComponent>{'Inside'}</TestComponent>);
-        const target = getByText('Inside');
+        render(<TestComponent>{'Inside'}</TestComponent>);
+        const target = screen.getByText('Inside');
 
         await user.pointer([{ keys: '[MouseLeft>]', target: target }, { target: outsideDiv }, { keys: '[/MouseLeft]' }]);
 
@@ -76,15 +75,15 @@ describe('useClickOutside', () => {
 
     test('should handle control elements', async () => {
         const user = userEvent.setup();
-        const { getByTestId } = render(
+        render(
             <>
                 <TestComponent />
                 <div data-testid="control">{'Control'}</div>
             </>
         );
 
-        const target = document.getElementById('target');
-        const control = getByTestId('control');
+        const target = screen.getByTestId('target');
+        const control = screen.getByTestId('control');
         (control as any)[CONTROL_ELEMENT_PROPERTY] = target;
 
         await user.click(control);
@@ -119,8 +118,8 @@ describe('useClickOutside', () => {
             );
         };
 
-        const { getByTestId } = render(<ComplexComponent />);
-        const control = getByTestId('control');
+        render(<ComplexComponent />);
+        const control = screen.getByTestId('control');
 
         await user.click(control);
 
@@ -137,13 +136,13 @@ describe('useClickOutside', () => {
     describe('Shadow DOM', () => {
         test('should not call callback when clicking inside a shadow dom which is inside the target', async () => {
             const user = userEvent.setup();
-            const { getByTestId } = render(
+            render(
                 <TestComponent>
                     <div data-testid="host"></div>
                 </TestComponent>
             );
 
-            const host = getByTestId('host');
+            const host = screen.getByTestId('host');
             const shadowRoot = host.attachShadow({ mode: 'open' });
             const shadowDiv = document.createElement('div');
             shadowDiv.textContent = 'Shadow Content';
@@ -156,13 +155,13 @@ describe('useClickOutside', () => {
 
         test('should not call callback when dragging from inside shadow dom to outside', async () => {
             const user = userEvent.setup();
-            const { getByTestId } = render(
+            render(
                 <TestComponent>
                     <div data-testid="host"></div>
                 </TestComponent>
             );
 
-            const host = getByTestId('host');
+            const host = screen.getByTestId('host');
             const shadowRoot = host.attachShadow({ mode: 'open' });
             const shadowDiv = document.createElement('div');
             shadowDiv.textContent = 'Shadow Content';
@@ -187,7 +186,7 @@ describe('useClickOutside', () => {
             const addSpy = vi.spyOn(popoverUtil, 'add');
             render(<TestComponent variant={ClickOutsideVariant.POPOVER} />);
 
-            const target = document.getElementById('target');
+            const target = screen.getByTestId('target');
             expect(addSpy).toHaveBeenCalledWith(target, callback);
         });
 
@@ -195,7 +194,7 @@ describe('useClickOutside', () => {
             const removeSpy = vi.spyOn(popoverUtil, 'remove');
             const { unmount } = render(<TestComponent variant={ClickOutsideVariant.POPOVER} />);
 
-            const target = document.getElementById('target');
+            const target = screen.getByTestId('target');
             unmount();
 
             expect(removeSpy).toHaveBeenCalledWith(target);
@@ -217,14 +216,14 @@ describe('useClickOutside', () => {
             const user = userEvent.setup();
             const parentFocusOut = vi.fn();
 
-            const { getByText } = render(
+            render(
                 // eslint-disable-next-line react/no-unknown-property, jsx-a11y/no-noninteractive-tabindex
                 <div onFocusOut={parentFocusOut} tabIndex={0}>
                     <TestComponent>{'Target'}</TestComponent>
                 </div>
             );
 
-            const target = getByText('Target');
+            const target = screen.getByText('Target');
 
             target.focus();
             await user.tab();
@@ -242,8 +241,8 @@ describe('useClickOutside', () => {
                 </div>
             );
 
-            const { getByText, rerender } = render(<Wrapper disable={false} />);
-            const target = getByText('Target');
+            const { rerender } = render(<Wrapper disable={false} />);
+            const target = screen.getByText('Target');
 
             target.focus();
             await user.tab();

--- a/src/hooks/element/useFocusTrap.test.tsx
+++ b/src/hooks/element/useFocusTrap.test.tsx
@@ -49,7 +49,7 @@ describe('useFocusTrap', () => {
         render(<TestComponent onEscape={onEscape} />);
 
         const root = screen.getByTestId('trap-root');
-        expect(document.activeElement).toBe(root);
+        expect(root).toHaveFocus();
     });
 
     test('should trap focus when tabbing forward from the last element', async () => {
@@ -61,11 +61,11 @@ describe('useFocusTrap', () => {
         const firstButton = buttons[0];
 
         lastButton.focus();
-        expect(document.activeElement).toBe(lastButton);
+        expect(lastButton).toHaveFocus();
 
         fireEvent.keyDown(lastButton, { key: 'Tab', code: 'Tab', shiftKey: false });
 
-        expect(document.activeElement).toBe(firstButton);
+        expect(firstButton).toHaveFocus();
     });
 
     test('should trap focus when tabbing backward from the first element', () => {
@@ -77,11 +77,11 @@ describe('useFocusTrap', () => {
         const lastButton = buttons[1];
 
         firstButton.focus();
-        expect(document.activeElement).toBe(firstButton);
+        expect(firstButton).toHaveFocus();
 
         fireEvent.keyDown(firstButton, { key: 'Tab', code: 'Tab', shiftKey: true });
 
-        expect(document.activeElement).toBe(lastButton);
+        expect(lastButton).toHaveFocus();
     });
 
     test('should call onEscape when Escape key is pressed', () => {
@@ -102,7 +102,7 @@ describe('useFocusTrap', () => {
 
         fireEvent.click(input);
         input.focus();
-        expect(document.activeElement).toBe(input);
+        expect(input).toHaveFocus();
     });
 
     test('should call onEscape when clicking outside', async () => {
@@ -112,14 +112,14 @@ describe('useFocusTrap', () => {
 
         const firstButton = screen.getAllByRole('button')[0]!;
         await user.click(firstButton);
-        expect(document.activeElement).toBe(firstButton);
+        expect(firstButton).toHaveFocus();
 
         const outsideButton = document.createElement('button');
         outsideButton.textContent = 'Outside';
         document.body.appendChild(outsideButton);
 
         await user.click(outsideButton);
-        expect(document.activeElement).toBe(outsideButton);
+        expect(outsideButton).toHaveFocus();
 
         expect(onEscape).toHaveBeenCalledWith(false);
 
@@ -149,6 +149,7 @@ describe('useFocusTrap', () => {
 
         shadowButton.dispatchEvent(clickEvent);
 
+        // eslint-disable-next-line testing-library/no-node-access
         expect(shadowRoot.activeElement).toBe(shadowButton);
     });
 });

--- a/src/hooks/useTabbedControl.test.tsx
+++ b/src/hooks/useTabbedControl.test.tsx
@@ -55,60 +55,69 @@ describe('useTabbedControl', () => {
     });
 
     test('should focus on the right option for navigation key pressed', () => {
+        const expectToBeFocused = (element: HTMLElement) => {
+            expect(element).toHaveAttribute('aria-checked', 'true');
+            expect(element).toHaveFocus();
+        };
+
         render(<TestComponent options={OPTIONS} />);
 
+        const radios = screen.getAllByRole('radio');
+        const firstOption = radios[0]!;
+
         // focus on first option
-        screen.getAllByRole('radio')[0]!.focus();
+        firstOption.focus();
 
         // confirm that first option has focus
-        expect(document.activeElement!.textContent).toBe('option_1');
-        expect(document.activeElement!.getAttribute('aria-checked')).toBe('true');
+        expectToBeFocused(firstOption);
+
+        let currentFocused = firstOption;
 
         // simulate pressing right arrow key multiple times
         for (let i = 0, j = 2; i < 5; i++, j++) {
             if (j > OPTIONS.length) j = 1;
 
-            fireEvent.keyDown(document.activeElement!, {
+            fireEvent.keyDown(currentFocused, {
                 key: InteractionKeyCode.ARROW_RIGHT,
                 code: InteractionKeyCode.ARROW_RIGHT,
             });
 
-            expect(document.activeElement!.textContent).toBe(`option_${j}`);
-            expect(document.activeElement!.getAttribute('aria-checked')).toBe('true');
+            currentFocused = radios[j - 1]!;
+            expectToBeFocused(currentFocused);
         }
 
         // simulate pressing home key
-        fireEvent.keyDown(document.activeElement!, {
+        fireEvent.keyDown(currentFocused, {
             key: InteractionKeyCode.HOME,
             code: InteractionKeyCode.HOME,
         });
 
         // confirm that first option has focus
-        expect(document.activeElement!.textContent).toBe('option_1');
-        expect(document.activeElement!.getAttribute('aria-checked')).toBe('true');
+        currentFocused = firstOption;
+        expectToBeFocused(currentFocused);
 
         // simulate pressing left arrow key multiple times
         for (let i = 0, j = 0; i < 5; i++, j--) {
             if (j === 0) j = OPTIONS.length;
 
-            fireEvent.keyDown(document.activeElement!, {
+            fireEvent.keyDown(currentFocused, {
                 key: InteractionKeyCode.ARROW_LEFT,
                 code: InteractionKeyCode.ARROW_LEFT,
             });
 
-            expect(document.activeElement!.textContent).toBe(`option_${j}`);
-            expect(document.activeElement!.getAttribute('aria-checked')).toBe('true');
+            currentFocused = radios[j - 1]!;
+            expectToBeFocused(currentFocused);
         }
 
         // simulate pressing end key
-        fireEvent.keyDown(document.activeElement!, {
+        fireEvent.keyDown(currentFocused, {
             key: InteractionKeyCode.END,
             code: InteractionKeyCode.END,
         });
 
         // confirm that last option has focus
-        expect(document.activeElement!.textContent).toBe('option_3');
-        expect(document.activeElement!.getAttribute('aria-checked')).toBe('true');
+        currentFocused = radios[OPTIONS.length - 1]!;
+        expectToBeFocused(currentFocused);
     });
 
     test('should have a unique id for each consumer', () => {

--- a/src/primitives/context/session/internal/deadline.ts
+++ b/src/primitives/context/session/internal/deadline.ts
@@ -50,7 +50,7 @@ export const createSessionDeadline = <T extends any>(emitter: Emitter<SessionEve
 
         if (_deadlines.length > 0) {
             let _deadlineElapsed = false;
-            let _signals = new Set<AbortSignal>();
+            const _signals = new Set<AbortSignal>();
 
             for (const deadline of _deadlines) {
                 if (isAbortSignal(deadline)) {

--- a/src/primitives/reactive/effectStack/main.test.ts
+++ b/src/primitives/reactive/effectStack/main.test.ts
@@ -94,7 +94,7 @@ describe('createEffectStack', () => {
         const boundFn1 = stack.bind(() => (RANDOM = Math.random()));
         const boundFn2 = stack.bind(value => !!value);
 
-        let EXCEPTION = 'uncaught_exception';
+        const EXCEPTION = 'uncaught_exception';
         let RANDOM = Math.random();
         let COUNTER = 0;
 

--- a/src/primitives/reactive/reflex/main.test.ts
+++ b/src/primitives/reactive/reflex/main.test.ts
@@ -101,7 +101,7 @@ describe('createReflexContainer', () => {
         expect(container.action).toBe(action);
         expect(container.reflex).not.toBeUndefined();
 
-        let reflex = container.reflex as NonNullable<Reflex<number>>;
+        const reflex = container.reflex as NonNullable<Reflex<number>>;
 
         container.release();
 
@@ -128,7 +128,7 @@ describe('createReflexContainer', () => {
 
         __reflexInstanceUpdateTests__(reflex, action);
 
-        let previous = reflex.current;
+        const previous = reflex.current;
 
         // same action so do nothing
         container.update(action);

--- a/src/primitives/reactive/reflex/main.ts
+++ b/src/primitives/reactive/reflex/main.ts
@@ -84,7 +84,8 @@ export const createReflexContainer = <T = any>(register: ReflexRegister = $globa
 
         _reflexAction = action;
 
-        _reflex = (_reflexable = currentReflexable) ? register.bind(_reflexable, _reflexAction) : createIsolatedFauxReflex(_reflexAction);
+        _reflexable = currentReflexable;
+        _reflex = _reflexable ? register.bind(_reflexable, _reflexAction) : createIsolatedFauxReflex(_reflexAction);
     };
 
     return struct<ReflexContainer<T>>({

--- a/src/utils/file/size.ts
+++ b/src/utils/file/size.ts
@@ -91,17 +91,17 @@ export const getHumanReadableFileSize = (bytes: number): string => {
     /*
      * The human-readable file size string is formed by joining the approximate file size and the byte scale
      * unit (Bytes, KB, MB, etc.), both of which are separated by a non-breaking whitespace. Non-breaking
-     * whitespace is used here instead of the regular whitespace to ensure that the human-readable file size
-     * string is presented without any line breaks (whenever possible).
+     * whitespace (\u00A0) is used here instead of the regular whitespace to ensure that the human-readable
+     * file size string is presented without any line breaks (whenever possible).
      */
     switch (scale) {
         case ByteScale.BYTES:
-            return `${size} byte${size === 1 ? '' : 's'}`;
+            return `${size}\u00A0byte${size === 1 ? '' : 's'}`;
         case ByteScale.KB:
-            return `${size} KB`;
+            return `${size}\u00A0KB`;
         case ByteScale.MB:
-            return `${size} MB`;
+            return `${size}\u00A0MB`;
         case ByteScale.GB:
-            return `${size} GB`;
+            return `${size}\u00A0GB`;
     }
 };

--- a/src/utils/file/upload.test.tsx
+++ b/src/utils/file/upload.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, expect, test } from 'vitest';
-import { act, fireEvent, render, screen } from '@testing-library/preact';
+import { fireEvent, render, screen } from '@testing-library/preact';
 import { userEvent } from '@testing-library/user-event';
 import { getUploadedFilesFromSource } from './upload';
 
@@ -50,10 +50,8 @@ const getDataTransferWithFiles = (files = FILES) => {
 
         const dropzone = screen.getByText(/drag files/i);
 
-        void act(() => {
-            fireEvent.drop(dropzone, {
-                dataTransfer: { files },
-            });
+        fireEvent.drop(dropzone, {
+            dataTransfer: { files },
         });
     });
 };

--- a/src/utils/preact/className.ts
+++ b/src/utils/preact/className.ts
@@ -4,7 +4,7 @@ import { JSX } from 'preact';
 const EXCESS_WHITESPACE_CHAR = /^\s+|\s+(?=\s|$)/g;
 
 export const parseClassName = (fallbackClassName: string, className: JSX.Signalish<string | undefined>): undefined | string => {
-    const classes = className ? (typeof className === 'string' ? className : className?.value ?? '') : '';
+    const classes = className ? (typeof className === 'string' ? className : (className?.value ?? '')) : '';
     return classes.replace(EXCESS_WHITESPACE_CHAR, '') || fallbackClassName.replace(EXCESS_WHITESPACE_CHAR, '') || undefined;
 };
 
@@ -15,4 +15,4 @@ export const getClassName = (
 ) => classnames(parseClassName('', requiredClassName), parseClassName(parseClassName('', fallbackClassName) || '', className));
 
 export const getModifierClasses = (prefix: string, modifiers: string[] = [], baseClasses: string[] = []): string =>
-    classnames([...baseClasses, ...modifiers?.map(m => (prefix ? `${prefix}--${m}` : m))]);
+    classnames([...baseClasses, ...modifiers.map(m => (prefix ? `${prefix}--${m}` : m))]);

--- a/src/utils/struct/main.test.ts
+++ b/src/utils/struct/main.test.ts
@@ -61,7 +61,9 @@ describe('struct', () => {
             // attempt writes
             obj.a = _aValue;
             obj.b = _bValue as any; // will throw an error
-        } catch {}
+        } catch {
+            /* intentionally empty */
+        }
 
         // modified `obj.a` (writable)
         expect(obj.a).not.toBe(aValue);
@@ -84,7 +86,9 @@ describe('struct', () => {
             Object.defineProperty(obj, 'a', {
                 get: bGetter, // will throw an error
             });
-        } catch {}
+        } catch {
+            /* intentionally empty */
+        }
 
         expect(Object.getOwnPropertyNames(obj)).toMatchObject(['a', 'b']);
         expect(Object.keys(obj)).toMatchObject([]); // `obj.b` is no longer enumerable
@@ -133,7 +137,9 @@ describe('structFrom', () => {
             // attempt writes
             obj.a = _aValue;
             obj.b = _bValue as any; // will throw an error
-        } catch {}
+        } catch {
+            /* intentionally empty */
+        }
 
         // modified `obj.a` (writable)
         expect(obj.a).not.toBe(aValue);
@@ -156,7 +162,9 @@ describe('structFrom', () => {
             Object.defineProperty(obj, 'a', {
                 get: bGetter, // will throw an error
             });
-        } catch {}
+        } catch {
+            /* intentionally empty */
+        }
 
         expect(Object.getOwnPropertyNames(obj)).toMatchObject(['a', 'b']);
         expect(Object.keys(obj)).toMatchObject([]); // `obj.b` is no longer enumerable


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces changes to fix the existing violations of the following ESLint rules across the entire project, with a few exceptions (which otherwise, might break the existing behavior in unintended ways).

- `testing-library/no-container`
- `testing-library/no-manual-cleanup`
- `testing-library/no-node-access`
- `testing-library/no-render-in-lifecycle`
- `testing-library/no-unnecessary-act`
- `testing-library/no-wait-for-multiple-assertions`
- `testing-library/prefer-screen-queries`
- `testing-library/render-result-naming-convention` 

**Fixed issue: [IEX-2406: Fix testing-library lint violations](https://youtrack.is.adyen.com/issue/IEX-2406)**
