### PR TITLE
fix: eslint general javascript

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -68,6 +68,8 @@ module.exports = {
                     'tests/**/*.{ts,js}',
                     'tests/**/**/*.spec.ts',
                     'src/utils/testing/**/*.{ts,tsx}',
+                    'src/**/__testing__/**/*.{ts,tsx}',
+                    'src/**/testing/**/*.{ts,tsx}',
                 ],
                 includeTypes: false,
             },

--- a/src/components/external/PaymentLinkCreation/components/Form/PaymentDetailsForm/Fields/ValidityField.tsx
+++ b/src/components/external/PaymentLinkCreation/components/Form/PaymentDetailsForm/Fields/ValidityField.tsx
@@ -41,7 +41,7 @@ export const ValidityField: FunctionalComponent<ValidityFieldProps> = ({ configu
                 return { id: FLEXIBLE_ID, name: i18n.get('payByLink.creation.fields.validity.linkValidityUnit.custom') };
             }
             const key: TranslationKey = `payByLink.creation.fields.validity.linkValidityUnit.${durationUnit}`;
-            return { id: `${quantity} ${durationUnit}` || '', name: i18n.get(key, { values: { quantity }, count: quantity }) };
+            return { id: `${quantity} ${durationUnit}`, name: i18n.get(key, { values: { quantity }, count: quantity }) };
         });
     }, [configuration, i18n]);
 

--- a/src/components/external/TransactionDetails/components/PaymentDetails/PaymentDetails.tsx
+++ b/src/components/external/TransactionDetails/components/PaymentDetails/PaymentDetails.tsx
@@ -52,7 +52,7 @@ const PaymentDetails = ({
         () =>
             TX_DETAILS_TABS.filter(({ id }) => {
                 switch (id) {
-                    case DetailsTab.SUMMARY:
+                    case DetailsTab.SUMMARY: {
                         const { additions, deductions, originalAmount, amountBeforeDeductions, netAmount } = transaction;
                         return (
                             (additions && additions.length > 0) ||
@@ -60,6 +60,7 @@ const PaymentDetails = ({
                             (originalAmount && originalAmount.value !== amountBeforeDeductions.value) ||
                             netAmount.value !== amountBeforeDeductions.value
                         );
+                    }
                     case DetailsTab.TIMELINE:
                         return transaction.events && transaction.events.length > 0;
                     default:

--- a/src/components/external/TransactionDetails/hooks/useInputNormalizer/useInputNormalizer.ts
+++ b/src/components/external/TransactionDetails/hooks/useInputNormalizer/useInputNormalizer.ts
@@ -14,7 +14,7 @@ export const createInputNormalizer = (maxChars = Infinity) => {
     }
 
     const _extensiveNormalize = (input: string) => {
-        let substringChars = maxChars === Infinity ? input.length : maxChars;
+        const substringChars = maxChars === Infinity ? input.length : maxChars;
         let normalizedChars = 0;
         let normalized = '';
 

--- a/src/components/internal/Calendar/calendar/timeframe/common/utils.ts
+++ b/src/components/internal/Calendar/calendar/timeframe/common/utils.ts
@@ -5,7 +5,9 @@ import { mod } from '../../../../../../utils';
 export const downsizeTimeFrame = (size: TimeFrameSize, maxsize: number): TimeFrameSize => {
     if (maxsize >= size) return size;
     let i = Math.max(1, FRAME_SIZES.indexOf(size));
-    while (--i && maxsize < (FRAME_SIZES[i] as TimeFrameSize)) {}
+    while (--i && maxsize < (FRAME_SIZES[i] as TimeFrameSize)) {
+        /* intentionally empty */
+    }
     return FRAME_SIZES[i] as TimeFrameSize;
 };
 

--- a/src/components/internal/Calendar/calendar/timerange/utils.ts
+++ b/src/components/internal/Calendar/calendar/timerange/utils.ts
@@ -46,6 +46,7 @@ export const getRangeTimestampsContextIntegerPropertyFactory = <T extends number
                 set(this: RangeTimestamps, value?: T | null) {
                     const currentValue = normalizedValue;
                     normalizedValue = _getNormalizedValue(value, normalizedValue);
+                    // eslint-disable-next-line no-self-assign
                     if (currentValue !== normalizedValue) this.now = this.now;
                 },
             }),

--- a/src/components/internal/Calendar/calendar/timeslice/TimeSlice.ts
+++ b/src/components/internal/Calendar/calendar/timeslice/TimeSlice.ts
@@ -13,7 +13,7 @@ export default class __TimeSlice__ {
     constructor(timezone?: string, time?: Time, timeEdge?: TimeFrameRangeEdge);
     constructor(...args: any[]) {
         if (args.length >= 3) {
-            let timestamp = new Date(args[1]).getTime();
+            const timestamp = new Date(args[1]).getTime();
 
             if (typeof args[2] !== 'symbol') {
                 this.#startTimestamp = timestamp || this.#startTimestamp;

--- a/src/components/internal/DataOverviewDetails/DataOverviewDetails.tsx
+++ b/src/components/internal/DataOverviewDetails/DataOverviewDetails.tsx
@@ -34,9 +34,10 @@ export default function DataOverviewDetails(props: ExternalUIComponentProps<Deta
                 fetchOptions: { enabled: !!props.id && !!getDetail },
                 queryFn: async () => {
                     switch (props.type) {
-                        case 'payout':
+                        case 'payout': {
                             const queryParam = { query: { balanceAccountId: props.id, createdAt: props.date } };
                             return getDetail!(EMPTY_OBJECT, { ...queryParam });
+                        }
                     }
                 },
             }),

--- a/src/core/Http/http.ts
+++ b/src/core/Http/http.ts
@@ -63,7 +63,7 @@ export async function http<T>(options: HttpOptions): Promise<T> {
 
                     //TODO: when backend is ready double check this logic
                     switch (contentType) {
-                        case 'application/json':
+                        case 'application/json': {
                             // This could throw an exception if response body content is not valid JSON
                             const text = await res.clone().text();
                             if (!text) {
@@ -73,10 +73,12 @@ export async function http<T>(options: HttpOptions): Promise<T> {
                                 return null;
                             }
                             return await res.json();
-                        default:
+                        }
+                        default: {
                             const blob = await res.blob();
                             const filename = getResponseDownloadFilename(res);
                             return { blob, filename } as const satisfies EndpointDownloadStreamData;
+                        }
                     }
                 } catch (ex) {
                     // If it does throw an exception, the exception will be propagated to the caller (unhandled).

--- a/src/core/Localization/datetime/restamper/restamper.test.ts
+++ b/src/core/Localization/datetime/restamper/restamper.test.ts
@@ -45,7 +45,7 @@ describe('restamper', () => {
     });
 
     test<RestamperTestContext>('should return restamp result for current time (when argument is omitted)', ({ restamper }) => {
-        let result = restamper();
+        const result = restamper();
 
         expect(result).toHaveProperty('formatted');
         expect(result).toHaveProperty('offset');

--- a/src/primitives/context/session/internal/deadline.ts
+++ b/src/primitives/context/session/internal/deadline.ts
@@ -50,7 +50,7 @@ export const createSessionDeadline = <T extends any>(emitter: Emitter<SessionEve
 
         if (_deadlines.length > 0) {
             let _deadlineElapsed = false;
-            let _signals = new Set<AbortSignal>();
+            const _signals = new Set<AbortSignal>();
 
             for (const deadline of _deadlines) {
                 if (isAbortSignal(deadline)) {

--- a/src/primitives/reactive/effectStack/main.test.ts
+++ b/src/primitives/reactive/effectStack/main.test.ts
@@ -94,7 +94,7 @@ describe('createEffectStack', () => {
         const boundFn1 = stack.bind(() => (RANDOM = Math.random()));
         const boundFn2 = stack.bind(value => !!value);
 
-        let EXCEPTION = 'uncaught_exception';
+        const EXCEPTION = 'uncaught_exception';
         let RANDOM = Math.random();
         let COUNTER = 0;
 

--- a/src/primitives/reactive/reflex/main.test.ts
+++ b/src/primitives/reactive/reflex/main.test.ts
@@ -101,7 +101,7 @@ describe('createReflexContainer', () => {
         expect(container.action).toBe(action);
         expect(container.reflex).not.toBeUndefined();
 
-        let reflex = container.reflex as NonNullable<Reflex<number>>;
+        const reflex = container.reflex as NonNullable<Reflex<number>>;
 
         container.release();
 
@@ -128,7 +128,7 @@ describe('createReflexContainer', () => {
 
         __reflexInstanceUpdateTests__(reflex, action);
 
-        let previous = reflex.current;
+        const previous = reflex.current;
 
         // same action so do nothing
         container.update(action);

--- a/src/primitives/reactive/reflex/main.ts
+++ b/src/primitives/reactive/reflex/main.ts
@@ -84,7 +84,8 @@ export const createReflexContainer = <T = any>(register: ReflexRegister = $globa
 
         _reflexAction = action;
 
-        _reflex = (_reflexable = currentReflexable) ? register.bind(_reflexable, _reflexAction) : createIsolatedFauxReflex(_reflexAction);
+        _reflexable = currentReflexable;
+        _reflex = _reflexable ? register.bind(_reflexable, _reflexAction) : createIsolatedFauxReflex(_reflexAction);
     };
 
     return struct<ReflexContainer<T>>({

--- a/src/utils/file/size.ts
+++ b/src/utils/file/size.ts
@@ -91,17 +91,17 @@ export const getHumanReadableFileSize = (bytes: number): string => {
     /*
      * The human-readable file size string is formed by joining the approximate file size and the byte scale
      * unit (Bytes, KB, MB, etc.), both of which are separated by a non-breaking whitespace. Non-breaking
-     * whitespace is used here instead of the regular whitespace to ensure that the human-readable file size
-     * string is presented without any line breaks (whenever possible).
+     * whitespace (\u00A0) is used here instead of the regular whitespace to ensure that the human-readable
+     * file size string is presented without any line breaks (whenever possible).
      */
     switch (scale) {
         case ByteScale.BYTES:
-            return `${size} byte${size === 1 ? '' : 's'}`;
+            return `${size}\u00A0byte${size === 1 ? '' : 's'}`;
         case ByteScale.KB:
-            return `${size} KB`;
+            return `${size}\u00A0KB`;
         case ByteScale.MB:
-            return `${size} MB`;
+            return `${size}\u00A0MB`;
         case ByteScale.GB:
-            return `${size} GB`;
+            return `${size}\u00A0GB`;
     }
 };

--- a/src/utils/preact/className.ts
+++ b/src/utils/preact/className.ts
@@ -4,7 +4,7 @@ import { JSX } from 'preact';
 const EXCESS_WHITESPACE_CHAR = /^\s+|\s+(?=\s|$)/g;
 
 export const parseClassName = (fallbackClassName: string, className: JSX.Signalish<string | undefined>): undefined | string => {
-    const classes = className ? (typeof className === 'string' ? className : className?.value ?? '') : '';
+    const classes = className ? (typeof className === 'string' ? className : (className?.value ?? '')) : '';
     return classes.replace(EXCESS_WHITESPACE_CHAR, '') || fallbackClassName.replace(EXCESS_WHITESPACE_CHAR, '') || undefined;
 };
 
@@ -15,4 +15,4 @@ export const getClassName = (
 ) => classnames(parseClassName('', requiredClassName), parseClassName(parseClassName('', fallbackClassName) || '', className));
 
 export const getModifierClasses = (prefix: string, modifiers: string[] = [], baseClasses: string[] = []): string =>
-    classnames([...baseClasses, ...modifiers?.map(m => (prefix ? `${prefix}--${m}` : m))]);
+    classnames([...baseClasses, ...modifiers.map(m => (prefix ? `${prefix}--${m}` : m))]);

--- a/src/utils/struct/main.test.ts
+++ b/src/utils/struct/main.test.ts
@@ -61,7 +61,9 @@ describe('struct', () => {
             // attempt writes
             obj.a = _aValue;
             obj.b = _bValue as any; // will throw an error
-        } catch {}
+        } catch {
+            /* intentionally empty */
+        }
 
         // modified `obj.a` (writable)
         expect(obj.a).not.toBe(aValue);
@@ -84,7 +86,9 @@ describe('struct', () => {
             Object.defineProperty(obj, 'a', {
                 get: bGetter, // will throw an error
             });
-        } catch {}
+        } catch {
+            /* intentionally empty */
+        }
 
         expect(Object.getOwnPropertyNames(obj)).toMatchObject(['a', 'b']);
         expect(Object.keys(obj)).toMatchObject([]); // `obj.b` is no longer enumerable
@@ -133,7 +137,9 @@ describe('structFrom', () => {
             // attempt writes
             obj.a = _aValue;
             obj.b = _bValue as any; // will throw an error
-        } catch {}
+        } catch {
+            /* intentionally empty */
+        }
 
         // modified `obj.a` (writable)
         expect(obj.a).not.toBe(aValue);
@@ -156,7 +162,9 @@ describe('structFrom', () => {
             Object.defineProperty(obj, 'a', {
                 get: bGetter, // will throw an error
             });
-        } catch {}
+        } catch {
+            /* intentionally empty */
+        }
 
         expect(Object.getOwnPropertyNames(obj)).toMatchObject(['a', 'b']);
         expect(Object.keys(obj)).toMatchObject([]); // `obj.b` is no longer enumerable


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces changes to fix the existing violations of the following ESLint rules across the entire project, with a few exceptions (which otherwise, might break the existing behavior in unintended ways).

- `import-x/no-extraneous-dependencies`
- `no-case-declarations`
- `no-cond-assign`
- `no-constant-binary-expression`
- `no-empty`
- `no-irregular-whitespace`
- `no-self-assign`
- `no-unsafe-optional-chaining`
- `prefer-const`

**Fixed issue: [IEX-2408: Fix JS general & import lint violations](https://youtrack.is.adyen.com/issue/IEX-2408)**
