### PR TITLE
Clean up analytic events

### DIFF
--- a/src/components/external/CapitalOffer/components/CapitalOffer/CapitalOffer.tsx
+++ b/src/components/external/CapitalOffer/components/CapitalOffer/CapitalOffer.tsx
@@ -12,7 +12,6 @@ import { useConfigContext } from '../../../../../core/ConfigContext';
 import { useFetch } from '../../../../../hooks/useFetch';
 import { EMPTY_OBJECT } from '../../../../../utils';
 import { CapitalOfferSummary } from '../CapitalOfferSummary/CapitalOfferSummary';
-import { useDurationEvent } from '../../../../../hooks/useAnalytics/useDurationEvent';
 import { useLandedPageEvent } from '../../../../../hooks/useAnalytics/useLandedPageEvent';
 import './CapitalOffer.scss';
 
@@ -72,7 +71,6 @@ const DynamicCapitalOffer: FunctionalComponent<ExternalUIComponentProps<CapitalO
     }, [selectedOffer]);
 
     useLandedPageEvent({ ...sharedAnalyticsEventProperties, label: 'Capital offer' });
-    useDurationEvent(sharedAnalyticsEventProperties);
 
     return (
         <div className={CAPITAL_OFFER_CLASS_NAMES.base}>

--- a/src/components/external/CapitalOffer/components/CapitalOfferSelection/CapitalOfferSelection.tsx
+++ b/src/components/external/CapitalOffer/components/CapitalOfferSelection/CapitalOfferSelection.tsx
@@ -6,7 +6,6 @@ import Button from '../../../../internal/Button/Button';
 import { ButtonVariant } from '../../../../internal/Button/types';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import useAnalyticsContext from '../../../../../core/Context/analytics/useAnalyticsContext';
-import { useDurationEvent } from '../../../../../hooks/useAnalytics/useDurationEvent';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { useConfigContext } from '../../../../../core/ConfigContext';
 import useMutation from '../../../../../hooks/useMutation/useMutation';
@@ -199,8 +198,6 @@ export const CapitalOfferSelection = ({
         () => reviewOfferMutation.isLoading || getDynamicGrantOfferMutation.isLoading || isLoading,
         [getDynamicGrantOfferMutation.isLoading, isLoading, reviewOfferMutation.isLoading]
     );
-
-    useDurationEvent(sharedAnalyticsEventProperties);
 
     return (
         <div className="adyen-pe-capital-offer-selection">

--- a/src/components/external/CapitalOffer/components/CapitalOfferSummary/CapitalOfferSummary.tsx
+++ b/src/components/external/CapitalOffer/components/CapitalOfferSummary/CapitalOfferSummary.tsx
@@ -11,7 +11,6 @@ import Button from '../../../../internal/Button/Button';
 import { ButtonVariant } from '../../../../internal/Button/types';
 import useMutation from '../../../../../hooks/useMutation/useMutation';
 import useAnalyticsContext from '../../../../../core/Context/analytics/useAnalyticsContext';
-import { useDurationEvent } from '../../../../../hooks/useAnalytics/useDurationEvent';
 import { useConfigContext } from '../../../../../core/ConfigContext';
 import { Tooltip } from '../../../../internal/Tooltip/Tooltip';
 import { EMPTY_OBJECT } from '../../../../../utils';
@@ -158,8 +157,6 @@ export const CapitalOfferSummary = ({
 
         return summaryItems;
     }, [grantOffer, i18n, maximumRepaymentPeriod]);
-
-    useDurationEvent(sharedAnalyticsEventProperties);
 
     return !requestErrorAlert && requestFundsMutation.error ? (
         <CapitalErrorMessageDisplay error={requestFundsMutation.error} onBack={onBackWithTracking} onContactSupport={onContactSupport} />

--- a/src/components/external/CapitalOverview/components/GrantActionsEmbedded/GrantActionsEmbedded.tsx
+++ b/src/components/external/CapitalOverview/components/GrantActionsEmbedded/GrantActionsEmbedded.tsx
@@ -1,5 +1,5 @@
 import { Fragment, FunctionalComponent } from 'preact';
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import Alert from '../../../../internal/Alert/Alert';
 import { AlertTypeOption } from '../../../../internal/Alert/types';
@@ -19,6 +19,8 @@ const CLASSNAMES = {
     actionButtonsContainer: 'adyen-pe-grant-actions-embedded__action-buttons-container',
     actionButton: 'adyen-pe-grant-actions-embedded__action-button',
 };
+
+const ANALYTICS_EVENT_DELAY_MS = 50;
 
 const sharedActionAnalyticsEventProps = {
     ...sharedCapitalOverviewAnalyticsEventProperties,
@@ -43,6 +45,8 @@ export const GrantActionsEmbedded: FunctionalComponent<GrantActionsEmbeddedProps
     const { i18n, environment } = useCoreContext();
     const userEvents = useAnalyticsContext();
     const { getOnboardingConfiguration } = useConfigContext().endpoints;
+    const completedActionsRef = useRef<Set<IMissingActionType>>(new Set());
+    const timeoutIdsRef = useRef<Map<IMissingActionType, ReturnType<typeof setTimeout>>>(new Map());
 
     const fetchToken = useCallback(async () => {
         const data = await getOnboardingConfiguration?.(EMPTY_OBJECT);
@@ -59,6 +63,14 @@ export const GrantActionsEmbedded: FunctionalComponent<GrantActionsEmbeddedProps
             onComplete();
         }
     }, [areActionsCompleted, onComplete]);
+
+    useEffect(() => {
+        const timeoutIds = timeoutIdsRef.current;
+        return () => {
+            timeoutIds.forEach(timeoutId => clearTimeout(timeoutId));
+            timeoutIds.clear();
+        };
+    }, []);
 
     const loadKYCComponent = useCallback(
         async (actionType: IMissingActionType) => {
@@ -155,16 +167,37 @@ export const GrantActionsEmbedded: FunctionalComponent<GrantActionsEmbeddedProps
         close();
     }, [activeAction, close]);
 
+    const handleClose = useCallback(
+        (actionType: IMissingActionType, analyticsProps: { subCategory: string; label: string }) => {
+            close();
+            const existingTimeout = timeoutIdsRef.current.get(actionType);
+            if (existingTimeout !== undefined) {
+                clearTimeout(existingTimeout);
+            }
+            const timeoutId = setTimeout(() => {
+                if (!completedActionsRef.current.has(actionType)) {
+                    userEvents.addEvent?.('Clicked button', {
+                        ...sharedActionAnalyticsEventProps,
+                        ...analyticsProps,
+                    });
+                }
+                completedActionsRef.current.delete(actionType);
+                timeoutIdsRef.current.delete(actionType);
+            }, ANALYTICS_EVENT_DELAY_MS);
+            timeoutIdsRef.current.set(actionType, timeoutId);
+        },
+        [close, userEvents]
+    );
+
     const handleBusinessFinancingClose = useCallback(() => {
-        close();
-        userEvents.addEvent?.('Clicked button', {
-            ...sharedActionAnalyticsEventProps,
+        handleClose('AnaCredit', {
             subCategory: 'Information',
             label: 'Dismissed AnaCredit information',
         });
-    }, [close, userEvents]);
+    }, [handleClose]);
 
     const handleBusinessFinancingComplete = useCallback(() => {
+        completedActionsRef.current.add('AnaCredit');
         completeAction();
         userEvents.addEvent?.('Clicked button', {
             ...sharedActionAnalyticsEventProps,
@@ -174,13 +207,11 @@ export const GrantActionsEmbedded: FunctionalComponent<GrantActionsEmbeddedProps
     }, [completeAction, userEvents]);
 
     const handleTermsOfServiceClose = useCallback(() => {
-        close();
-        userEvents.addEvent?.('Clicked button', {
-            ...sharedActionAnalyticsEventProps,
+        handleClose('signToS', {
             subCategory: 'Terms & conditions',
             label: 'Dismissed terms & conditions',
         });
-    }, [close, userEvents]);
+    }, [handleClose]);
 
     const handleTermsOfServiceAccept = useCallback(() => {
         userEvents.addEvent?.('Clicked button', {
@@ -191,6 +222,7 @@ export const GrantActionsEmbedded: FunctionalComponent<GrantActionsEmbeddedProps
     }, [userEvents]);
 
     const handleTermsOfServiceComplete = useCallback(() => {
+        completedActionsRef.current.add('signToS');
         completeAction();
         userEvents.addEvent?.('Clicked button', {
             ...sharedActionAnalyticsEventProps,

--- a/tests/integration/components/capitalOffer/default.spec.ts
+++ b/tests/integration/components/capitalOffer/default.spec.ts
@@ -13,7 +13,6 @@ const goToOfferSummary = async (page: Page, analyticsEvents: PageAnalyticsEvent[
     await page.getByRole('button', { name: 'Review offer' }).click();
     await expectAnalyticsEvents(analyticsEvents, [
         ['Clicked button', { ...sharedCapitalOfferSelectionAnalyticsEventProperties, label: 'Review offer' }],
-        ['Duration', sharedCapitalOfferSelectionAnalyticsEventProperties],
     ]);
 };
 
@@ -113,7 +112,6 @@ test.describe('Default', () => {
 
         await expectAnalyticsEvents(analyticsEvents, [
             ['Clicked button', { ...sharedCapitalOfferSummaryAnalyticsEventProperties, label: 'Back to slider view' }],
-            ['Duration', sharedCapitalOfferSummaryAnalyticsEventProperties],
         ]);
 
         await expect(page.getByText('Business financing offer')).toBeVisible();

--- a/tests/integration/components/capitalOverview/grantMultipleActionsEmbedded.spec.ts
+++ b/tests/integration/components/capitalOverview/grantMultipleActionsEmbedded.spec.ts
@@ -98,11 +98,7 @@ test.describe('Grant: Multiple actions - Embedded', () => {
         await submitBusinessFinancingInformation(page);
         await expect(page.getByText('Information submitted')).toBeVisible();
 
-        await expectAnalyticsEvents(analyticsEvents, [
-            clickedButtonEvents.submitInformationClicked,
-            clickedButtonEvents.dismissedAnaCredit,
-            clickedButtonEvents.submittedAnaCredit,
-        ]);
+        await expectAnalyticsEvents(analyticsEvents, [clickedButtonEvents.submitInformationClicked, clickedButtonEvents.submittedAnaCredit]);
     });
 
     test('should render terms of service component when signing button in clicked', async ({ page, analyticsEvents }) => {
@@ -132,7 +128,6 @@ test.describe('Grant: Multiple actions - Embedded', () => {
         await expectAnalyticsEvents(analyticsEvents, [
             clickedButtonEvents.signTermsClicked,
             clickedButtonEvents.signedTerms,
-            clickedButtonEvents.dismissedTerms,
             clickedButtonEvents.finishedTerms,
         ]);
     });

--- a/tests/integration/components/capitalOverview/newOffer.spec.ts
+++ b/tests/integration/components/capitalOverview/newOffer.spec.ts
@@ -24,7 +24,6 @@ const goToOfferSummary = async (page: Page, analyticsEvents: PageAnalyticsEvent[
 
     await expectAnalyticsEvents(analyticsEvents, [
         ['Clicked button', { ...sharedCapitalOfferSelectionAnalyticsEventProperties, label: 'Review offer' }],
-        ['Duration', sharedCapitalOfferSelectionAnalyticsEventProperties],
     ]);
 };
 
@@ -49,11 +48,7 @@ test.describe('New offer', () => {
         await goToOfferSelection(page, analyticsEvents);
         await page.getByRole('button', { name: 'Go back' }).click();
 
-        await expectAnalyticsEvents(analyticsEvents, [
-            ['Duration', sharedCapitalOfferAnalyticsEventProperties],
-            ['Duration', sharedCapitalOfferSelectionAnalyticsEventProperties],
-            ['Landed on page', sharedGrantsOverviewAnalyticsEventProperties],
-        ]);
+        await expectAnalyticsEvents(analyticsEvents, [['Landed on page', sharedGrantsOverviewAnalyticsEventProperties]]);
 
         await expect(page.getByText('Business financing', { exact: true })).toBeVisible();
     });
@@ -67,8 +62,6 @@ test.describe('New offer', () => {
 
         await expectAnalyticsEvents(analyticsEvents, [
             ['Clicked button', { ...sharedCapitalOfferSummaryAnalyticsEventProperties, label: 'Request funds' }],
-            ['Duration', sharedCapitalOfferAnalyticsEventProperties],
-            ['Duration', sharedCapitalOfferSummaryAnalyticsEventProperties],
             ['Landed on page', { ...sharedGrantsOverviewAnalyticsEventProperties, subCategory: 'Grants overview' }],
         ]);
 

--- a/tests/integration/components/capitalOverview/prequalified.spec.ts
+++ b/tests/integration/components/capitalOverview/prequalified.spec.ts
@@ -24,7 +24,6 @@ const goToOfferSummary = async (page: Page, analyticsEvents: PageAnalyticsEvent[
 
     await expectAnalyticsEvents(analyticsEvents, [
         ['Clicked button', { ...sharedCapitalOfferSelectionAnalyticsEventProperties, label: 'Review offer' }],
-        ['Duration', sharedCapitalOfferSelectionAnalyticsEventProperties],
     ]);
 };
 
@@ -51,11 +50,7 @@ test.describe('Prequalified', () => {
         await goToOfferSelection(page, analyticsEvents);
         await page.getByRole('button', { name: 'Go back' }).click();
 
-        await expectAnalyticsEvents(analyticsEvents, [
-            ['Duration', sharedCapitalOfferAnalyticsEventProperties],
-            ['Duration', sharedCapitalOfferSelectionAnalyticsEventProperties],
-            ['Landed on page', sharedPrequalifiedAnalyticsEventProperties],
-        ]);
+        await expectAnalyticsEvents(analyticsEvents, [['Landed on page', sharedPrequalifiedAnalyticsEventProperties]]);
 
         await expect(page.getByText('Need some extra money?')).toBeVisible();
     });
@@ -69,8 +64,6 @@ test.describe('Prequalified', () => {
 
         await expectAnalyticsEvents(analyticsEvents, [
             ['Clicked button', { ...sharedCapitalOfferSummaryAnalyticsEventProperties, label: 'Request funds' }],
-            ['Duration', sharedCapitalOfferAnalyticsEventProperties],
-            ['Duration', sharedCapitalOfferSummaryAnalyticsEventProperties],
             ['Landed on page', { ...sharedPrequalifiedAnalyticsEventProperties, subCategory: 'Grants overview' }],
         ]);
 


### PR DESCRIPTION
When users successfully complete business financing or terms of service flows, both oncomplete and onclose callbacks fire  on onboarding components (by design). This caused duplicate analytics events - both "Dismissed" and "Finished" analytic events were triggered. However analysts want only the "Finished" event in this case.

Also "Duration" events are removed, as requested by analysts.