### PR TITLE
fix: rename $insertId to $insert_id

### DIFF
--- a/src/core/Analytics/analytics/user-events.ts
+++ b/src/core/Analytics/analytics/user-events.ts
@@ -141,8 +141,8 @@ export class UserEvents {
      */
     public addEvent(eventName: EventName, properties: AdditionalEventProperties) {
         const time = getEventTime();
-        const $insertId = getEventInsertId();
-        const completeEvent = { ...this.baseTrackingPayload, $insertId, time, ...properties } as AnalyticsEventPayload;
+        const $insert_id = getEventInsertId();
+        const completeEvent = { ...this.baseTrackingPayload, $insert_id, time, ...properties } as AnalyticsEventPayload;
         this.add({
             name: eventName,
             // type: 'add_event',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces a small change to rename the analytics event insert ID property from `$insertId` to `$insert_id`.
