### PR TITLE
fix: add missing analytics event insert ID for core events

### DIFF
--- a/src/core/Analytics/analytics/customTranslations.ts
+++ b/src/core/Analytics/analytics/customTranslations.ts
@@ -1,7 +1,7 @@
 import Localization from '../../Localization';
 import currentTranslations from '../../../assets/translations/en-US.json' with { type: 'json' };
 import { SUPPORTED_LOCALES } from '../../Localization/constants/localization';
-import { encodeAnalyticsEvent, getEventTime } from './utils';
+import { encodeAnalyticsEvent, getEventInsertId, getEventTime } from './utils';
 import { getUserAgent } from '../../runtime';
 
 export const oldTranslationKeys = new Set([
@@ -808,7 +808,7 @@ export const getCustomTranslationsAnalyticsPayload = (customTranslations: Locali
             if (!SUPPORTED_LOCALES.includes(locale as any)) {
                 const newLanguageEvent = encodeAnalyticsEvent({
                     event: 'Added new language',
-                    properties: { ...baseEventProperties, time: getEventTime() },
+                    properties: { ...baseEventProperties, time: getEventTime(), $insert_id: getEventInsertId() },
                 });
                 if (newLanguageEvent) {
                     payloads.push(newLanguageEvent);
@@ -824,7 +824,12 @@ export const getCustomTranslationsAnalyticsPayload = (customTranslations: Locali
                     if (oldCustomizedKeys.length > 0) {
                         const oldTranslationsEvent = encodeAnalyticsEvent({
                             event: 'Customized old translation',
-                            properties: { ...baseEventProperties, keys: oldCustomizedKeys, time: getEventTime() },
+                            properties: {
+                                ...baseEventProperties,
+                                keys: oldCustomizedKeys,
+                                time: getEventTime(),
+                                $insert_id: getEventInsertId(),
+                            },
                         });
                         if (oldTranslationsEvent) {
                             payloads.push(oldTranslationsEvent);
@@ -836,7 +841,7 @@ export const getCustomTranslationsAnalyticsPayload = (customTranslations: Locali
                     // This event is permanent to keep track of all the customizations that user made to translations
                     const allTranslationsEvent = encodeAnalyticsEvent({
                         event: 'Customized translation',
-                        properties: { ...baseEventProperties, keys: matchingCustomizedKeys, time: getEventTime() },
+                        properties: { ...baseEventProperties, keys: matchingCustomizedKeys, time: getEventTime(), $insert_id: getEventInsertId() },
                     });
                     if (allTranslationsEvent) {
                         payloads.push(allTranslationsEvent);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces changes to add missing `$insert_id` to the payload for core analytics events.
