### PR TITLE
fix: missing VITE_VERSION for Storybook

### DIFF
--- a/packages/tools/storybook-preact/.storybook/main.ts
+++ b/packages/tools/storybook-preact/.storybook/main.ts
@@ -5,6 +5,7 @@ import { preact } from '@preact/preset-vite';
 import svgr from 'vite-plugin-svgr';
 import { getEnvironment } from '../../../../envs/getEnvs.ts';
 import { realApiProxies } from '../../../../endpoints/realApiProxies.js';
+import rootPackageJson from '../../../../package.json' with { type: 'json' };
 
 // Inlined env defines. Importing config/build-env-defines.ts would pull its
 // transitive src/ imports through Storybook's loader; only the runtime env vars
@@ -30,6 +31,7 @@ const getStorybookDefines = (mode: string) => {
         'process.env.TEST_ENV': JSON.stringify(process.env.TEST_ENV),
         'process.env.USE_CDN': JSON.stringify(app.useCdn ?? null),
         'process.env.VITE_TEST_CDN_ASSETS': JSON.stringify(testCdnAssets),
+        'process.env.VITE_VERSION': JSON.stringify(rootPackageJson.version),
     };
 };
 

--- a/packages/tools/storybook-vue/.storybook/main.ts
+++ b/packages/tools/storybook-vue/.storybook/main.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import vue from '@vitejs/plugin-vue';
 import { getEnvironment } from '../../../../envs/getEnvs.ts';
 import { realApiProxies } from '../../../../endpoints/realApiProxies.js';
+import rootPackageJson from '../../../../package.json' with { type: 'json' };
 
 // Inlined env-variable defines. See the equivalent block in storybook-preact
 // main.ts for the rationale (avoids transitive directory imports).
@@ -28,6 +29,7 @@ const getStorybookDefines = (mode: string) => {
         'process.env.TEST_ENV': JSON.stringify(process.env.TEST_ENV),
         'process.env.USE_CDN': JSON.stringify(app.useCdn ?? null),
         'process.env.VITE_TEST_CDN_ASSETS': JSON.stringify(testCdnAssets),
+        'process.env.VITE_VERSION': JSON.stringify(rootPackageJson.version),
     };
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces some changes to define the missing `process.env.VITE_VERSION` variable in the build configurations for the Storybook packages.
