### PR TITLE
Expose SDK global

### DIFF
--- a/src/declarations/global.d.ts
+++ b/src/declarations/global.d.ts
@@ -3,15 +3,15 @@ export {};
 
 declare global {
     /**
-     * Shape of the global `window.AdyenPlatformExperienceSDK` object.
+     * Shape of the global `window.AdyenPlatformExperienceMetadata` object.
      */
-    interface AdyenPlatformExperienceSDK {
+    interface AdyenPlatformExperienceMetadata {
         /** The SDK version (e.g. 1.11.0) */
         readonly version: string;
     }
 
     interface Window {
         /** Read-only global set by the SDK at runtime. */
-        readonly AdyenPlatformExperienceSDK: AdyenPlatformExperienceSDK;
+        readonly AdyenPlatformExperienceMetadata: AdyenPlatformExperienceMetadata;
     }
 }

--- a/src/declarations/global.d.ts
+++ b/src/declarations/global.d.ts
@@ -1,0 +1,17 @@
+// Makes this a module (required since this file has no other imports)
+export {};
+
+declare global {
+    /**
+     * Shape of the global `window.AdyenPlatformExperienceSDK` object.
+     */
+    interface AdyenPlatformExperienceSDK {
+        /** The SDK version (e.g. 1.11.0) */
+        readonly version: string;
+    }
+
+    interface Window {
+        /** Read-only global set by the SDK at runtime. */
+        readonly AdyenPlatformExperienceSDK: AdyenPlatformExperienceSDK;
+    }
+}

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,0 +1,36 @@
+// Pulls in the global augmentations (AdyenPlatformExperienceSDK, Window) from the declaration file.
+// Using `import type` rather than a triple-slash reference to avoid @typescript-eslint/triple-slash-reference errors.
+import type {} from './declarations/global';
+import { Core } from './core';
+
+/** A property with this name will be exposed via the global (window) object. */
+const globalKey = 'AdyenPlatformExperienceSDK' satisfies keyof typeof window;
+
+/**
+ * Creates a null-prototype object whose properties are non-writable and non-configurable.
+ * Used to produce a frozen-like struct that cannot be accidentally reassigned or deleted.
+ */
+const fixedStruct = <T extends Record<string, any>>(obj: T) => {
+    const descriptors = (Object.entries(obj) as [keyof T, T[keyof T]][]).reduce(
+        (descriptors, [key, value]) => {
+            descriptors[key] = { value, enumerable: true };
+            return descriptors;
+        },
+        {} as { [K in keyof T]: { value: T[K]; enumerable: true } }
+    );
+
+    return Object.create(Object.prototype, descriptors);
+};
+
+if (typeof window !== 'undefined' && !(globalKey in window)) {
+    const globalObj: AdyenPlatformExperienceSDK = {
+        version: Core.version,
+    } as const;
+
+    Object.defineProperty(window, globalKey, {
+        value: fixedStruct(globalObj),
+        enumerable: true,
+    });
+}
+
+export default globalKey;

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,10 +1,10 @@
-// Pulls in the global augmentations (AdyenPlatformExperienceSDK, Window) from the declaration file.
+// Pulls in the global augmentations (AdyenPlatformExperienceMetadata, Window) from the declaration file.
 // Using `import type` rather than a triple-slash reference to avoid @typescript-eslint/triple-slash-reference errors.
 import type {} from './declarations/global';
 import { Core } from './core';
 
 /** A property with this name will be exposed via the global (window) object. */
-const globalKey = 'AdyenPlatformExperienceSDK' satisfies keyof typeof window;
+const globalKey = 'AdyenPlatformExperienceMetadata' satisfies keyof typeof window;
 
 /**
  * Creates a null-prototype object whose properties are non-writable and non-configurable.
@@ -23,7 +23,7 @@ const fixedStruct = <T extends Record<string, any>>(obj: T) => {
 };
 
 if (typeof window !== 'undefined' && !(globalKey in window)) {
-    const globalObj: AdyenPlatformExperienceSDK = {
+    const globalObj: AdyenPlatformExperienceMetadata = {
         version: Core.version,
     } as const;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Core, CoreOptions, TranslationSourceRecord } from './core';
 import './style/index.scss';
+import './global';
 
 export * from './core';
 export * from './components';

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -3,6 +3,7 @@
     "include": [],
     "files": [
         "src/index.ts",
+        "src/declarations/global.d.ts",
         "src/declarations/scss.d.ts",
         "src/declarations/vite-env.d.ts",
         "src/declarations/svgr.d.ts"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces changes to add a global property to the `window` object when the SDK loads. This could be used to provide useful SDK metadata and debugging information.
