### PR TITLE
fix: correct resolve paths for storybook package

### DIFF
--- a/packages/tools/storybook/src/.storybook/vue/main.ts
+++ b/packages/tools/storybook/src/.storybook/vue/main.ts
@@ -38,8 +38,8 @@ const config: StorybookConfig = {
             resolve: {
                 dedupe: ['vue', 'vue-i18n'],
                 alias: {
-                    vue: resolve(rootDir, 'packages/tools/storybook-vue/node_modules/vue'),
-                    'vue-i18n': resolve(rootDir, 'packages/tools/storybook-vue/node_modules/vue-i18n'),
+                    vue: resolve(rootDir, 'packages/tools/storybook/node_modules/vue'),
+                    'vue-i18n': resolve(rootDir, 'packages/tools/storybook/node_modules/vue-i18n'),
                 },
             },
             css: {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR fixes an issue introduced in a previous PR, to correctly resolve paths for the Vue dependencies of the `tools-storybook` package.
