### PR TITLE
feat: deprecation warning for availableTranslations option

### DIFF
--- a/packages/shared/core/src/Core.test.ts
+++ b/packages/shared/core/src/Core.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Core, { AVAILABLE_TRANSLATIONS_DEPRECATION_WARNING } from './Core';
+import { SERVER_SIDE_INITIALIZATION_WARNING } from './runtime';
+
+describe('Core', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    beforeEach(() => {
+        process.env.NODE_ENV = 'development';
+    });
+
+    afterEach(() => {
+        process.env.NODE_ENV = originalNodeEnv;
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('should warn when availableTranslations option is provided', () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        new Core({
+            locale: 'en-US',
+            onSessionCreate: vi.fn(),
+            availableTranslations: [],
+        });
+
+        const warningCalls = consoleWarnSpy.mock.calls.filter(([message]) => message === AVAILABLE_TRANSLATIONS_DEPRECATION_WARNING);
+        expect(warningCalls).toHaveLength(1);
+    });
+
+    it('should warn only once for availableTranslations even after multiple updates', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const core = new Core({
+            locale: 'en-US',
+            onSessionCreate: vi.fn(),
+            availableTranslations: [],
+        });
+
+        await core.update({});
+        await core.update({});
+
+        const warningCalls = consoleWarnSpy.mock.calls.filter(([message]) => message === AVAILABLE_TRANSLATIONS_DEPRECATION_WARNING);
+        expect(warningCalls).toHaveLength(1);
+    });
+
+    it('should not warn when availableTranslations option is not provided', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        new Core({
+            locale: 'en-US',
+            onSessionCreate: vi.fn(),
+        });
+
+        const warningCalls = consoleWarnSpy.mock.calls.filter(([message]) => message === AVAILABLE_TRANSLATIONS_DEPRECATION_WARNING);
+        expect(warningCalls).toHaveLength(0);
+    });
+
+    it('should warn once when initialized server-side in development mode', async () => {
+        vi.stubGlobal('window', undefined);
+
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const core = new Core({
+            locale: 'en-US',
+            onSessionCreate: vi.fn(),
+        });
+
+        await core.initialize();
+        await core.initialize();
+
+        const warningCalls = consoleWarnSpy.mock.calls.filter(([message]) => message === SERVER_SIDE_INITIALIZATION_WARNING);
+
+        expect(warningCalls).toHaveLength(1);
+    });
+});

--- a/packages/shared/core/src/Core.ts
+++ b/packages/shared/core/src/Core.ts
@@ -1,4 +1,4 @@
-import { EMPTY_OBJECT } from '@integration-components/utils';
+import { EMPTY_OBJECT, hasOwnProperty } from '@integration-components/utils';
 import { AuthSession } from './session/AuthSession';
 import Localization from './Localization';
 import { Assets, AssetOptions } from './Assets/Assets';
@@ -20,6 +20,9 @@ export interface ManagedElement {
 }
 
 export type CdnFetcher = <Fallback>(props: { name: string; extension?: string; subFolder?: string; fallback?: Fallback }) => Promise<Fallback>;
+
+export const AVAILABLE_TRANSLATIONS_DEPRECATION_WARNING =
+    '[AdyenPlatFormExperience] The "availableTranslations" option is deprecated and will be removed in a future major version. You can safely remove this option.';
 
 /**
  * Framework-agnostic source of truth for the Core runtime. Owns option resolution,
@@ -44,6 +47,7 @@ export class Core<AvailableTranslations extends TranslationSourceRecord[] = [], 
     public getCdnDataset!: CdnFetcher;
     public components: ManagedElement[] = [];
 
+    private hasWarnedAboutAvailableTranslationsDeprecation = false;
     private hasWarnedAboutServerSideInitialization = false;
     private readyCustomTranslationsAnalytics = false;
 
@@ -89,6 +93,11 @@ export class Core<AvailableTranslations extends TranslationSourceRecord[] = [], 
 
         if (analyticsChanged) {
             this.applyAnalyticsOptions();
+        }
+
+        if (!this.hasWarnedAboutAvailableTranslationsDeprecation && hasOwnProperty(this.options, 'availableTranslations')) {
+            console.warn(AVAILABLE_TRANSLATIONS_DEPRECATION_WARNING);
+            this.hasWarnedAboutAvailableTranslationsDeprecation = true;
         }
 
         this.session.loadingContext = this.loadingContext;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR introduces a deprecation warning for the `availableTranslations` Core option. This option is currently ignored, and is marked for removal in the next major version.
