### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - if: >-
           github.event.pull_request.user.login == 'github-actions[bot]'
-          && github.event.pull_request.head.ref == 'main'
+          && startsWith(github.event.pull_request.head.ref, 'chore/sync-main-into-develop')
           && startsWith(github.event.pull_request.title, 'chore(release): sync main into develop')
         id: skip
         run: echo "Skipping integration tests (automated sync PR)"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -97,6 +97,12 @@ jobs:
               git checkout -b "$PRERELEASE_BRANCH"
             fi
 
+            # Strip internal workspace packages from pre.json so that only the
+            # root package is bumped when exiting pre-release mode.
+            jq '.initialVersions |= with_entries(select(.key == "@adyen/adyen-platform-experience-web"))' \
+              .changeset/pre.json > .changeset/pre.json.tmp \
+              && mv .changeset/pre.json.tmp .changeset/pre.json
+
             pnpm changeset pre exit
             git add .changeset/pre.json
             git commit -m "chore(release): exit pre-release mode"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -71,9 +71,6 @@ jobs:
           # Enter pre-release mode if not already active
           if [ ! -f .changeset/pre.json ]; then
             pnpm changeset pre enter "$TAG"
-            jq '.initialVersions |= with_entries(select(.key == "@adyen/adyen-platform-experience-web"))' \
-              .changeset/pre.json > .changeset/pre.json.tmp \
-              && mv .changeset/pre.json.tmp .changeset/pre.json
             git add .changeset/pre.json
             git commit -m "chore(release): enter pre-release mode ($TAG)"
           fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -71,13 +71,16 @@ jobs:
           # Enter pre-release mode if not already active
           if [ ! -f .changeset/pre.json ]; then
             pnpm changeset pre enter "$TAG"
+            jq '.initialVersions |= with_entries(select(.key == "@adyen/adyen-platform-experience-web"))' \
+              .changeset/pre.json > .changeset/pre.json.tmp \
+              && mv .changeset/pre.json.tmp .changeset/pre.json
             git add .changeset/pre.json
             git commit -m "chore(release): enter pre-release mode ($TAG)"
           fi
 
           git push origin "$PRERELEASE_BRANCH"
 
-      # ── Stable: if pre-release mode is active, exit it on the pre-release branch (auto-promote) ──
+      # ── Stable: if pre-release mode is active, exit it on a promotion branch (auto-promote) ──
       - name: Prepare stable release
         if: inputs.release_type == 'stable'
         env:
@@ -85,16 +88,16 @@ jobs:
         run: |
           if [ -f .changeset/pre.json ]; then
             echo "Pre-release mode detected, promoting to stable from main..."
-            PRERELEASE_BRANCH="pre-release/$TAG"
+            PROMOTE_BRANCH="chore/promote-$TAG-to-stable"
 
             # Create the promote branch from main (pre-releases are already merged there)
             git checkout main
-            if git ls-remote --heads origin "$PRERELEASE_BRANCH" | grep -q "$PRERELEASE_BRANCH"; then
-              git fetch origin "$PRERELEASE_BRANCH"
-              git checkout "$PRERELEASE_BRANCH"
+            if git ls-remote --heads origin "$PROMOTE_BRANCH" | grep -q "$PROMOTE_BRANCH"; then
+              git fetch origin "$PROMOTE_BRANCH"
+              git checkout "$PROMOTE_BRANCH"
               git merge main --no-edit
             else
-              git checkout -b "$PRERELEASE_BRANCH"
+              git checkout -b "$PROMOTE_BRANCH"
             fi
 
             # Strip internal workspace packages from pre.json so that only the
@@ -106,9 +109,9 @@ jobs:
             pnpm changeset pre exit
             git add .changeset/pre.json
             git commit -m "chore(release): exit pre-release mode"
-            git push origin "$PRERELEASE_BRANCH"
+            git push origin "$PROMOTE_BRANCH"
 
-            echo "HEAD_BRANCH=$PRERELEASE_BRANCH" >> "$GITHUB_ENV"
+            echo "HEAD_BRANCH=$PROMOTE_BRANCH" >> "$GITHUB_ENV"
           else
             echo "HEAD_BRANCH=develop" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,7 @@ jobs:
         id: skip-check
         if: >-
           github.event.pull_request.user.login == 'github-actions[bot]'
-          && github.event.pull_request.head.ref == 'main'
+          && startsWith(github.event.pull_request.head.ref, 'chore/sync-main-into-develop')
           && startsWith(github.event.pull_request.title, 'chore(release): sync main into develop')
         run: echo "Skipping build (automated sync PR)"
 

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -86,18 +86,22 @@ jobs:
           # Strips everything up to and including the last @ (the package name), then prepends v, e.g. v1.0.0
           SEMVER_TAG="v${SCOPED_TAG##*@}"
 
-          # Recreate the tag under the semver name and remove the scoped one
+          # Create the semver tag pointing at the same commit as the scoped one
           git tag "$SEMVER_TAG" "$SCOPED_TAG"
           git push origin "$SEMVER_TAG"
-          git tag -d "$SCOPED_TAG"
-          git push origin --delete "$SCOPED_TAG"
 
-          # Update the GitHub release to point to the new tag and publish it
+          # Update the GitHub release to point to the new tag and publish it.
+          # This must run before deleting the scoped tag so the release is still
+          # findable by its tag_name via the GitHub API.
           PRERELEASE_FLAG=""
           if [[ "${{ env.IS_PRERELEASE }}" == "true" ]]; then
             PRERELEASE_FLAG="--prerelease"
           fi
           gh release edit "$SCOPED_TAG" --tag "$SEMVER_TAG" --title "$SEMVER_TAG" --draft=false $PRERELEASE_FLAG
+
+          # Remove the scoped tag now that the release points to the semver tag
+          git tag -d "$SCOPED_TAG"
+          git push origin --delete "$SCOPED_TAG"
 
       - name: Upload Release Asset
         env:
@@ -156,18 +160,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.create-github-release.outputs.release_version }}
         run: |
+          SYNC_BRANCH="chore/sync-main-into-develop-v$VERSION"
+
           # Check if a sync PR already exists
-          EXISTING=$(gh pr list --base develop --head main --state open --json number --jq '.[0].number')
+          EXISTING=$(gh pr list --base develop --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number')
           if [ -n "$EXISTING" ]; then
             echo "Sync PR #$EXISTING already exists, skipping."
             exit 0
           fi
 
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$SYNC_BRANCH" origin/main
+          git push origin "$SYNC_BRANCH"
+
           gh pr create \
             --base develop \
-            --head main \
+            --head "$SYNC_BRANCH" \
             --title "chore(release): sync main into develop after v$VERSION" \
-            --body "Syncs version bump and consumed changesets from pre-release v$VERSION into develop."
+            --body "Syncs version bump and consumed changesets from v$VERSION into develop."
 
   upload-assets:
     if: needs.create-github-release.outputs.is_prerelease != 'true'


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR includes the following changes and updates to fix the current release workflows.

- Exclude internal (`@integration-components`) packages from stable release
- Open PR from intermediate branch to update `develop` with `main` after release
- Skip drafts for GitHub releases and release immediately