### PR TITLE
Fix renewed grant filtering

### DIFF
--- a/.changeset/weak-coins-invent.md
+++ b/.changeset/weak-coins-invent.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-platform-experience-web': patch
+---
+
+In the Capital Overview component, we resolved an issue where a closed grant could be incorrectly hidden from the grant list if it was later renewed. Only active grants that are renewed are now filtered out of the list.

--- a/packages/domains/capital/mocks/mock-data/capital.ts
+++ b/packages/domains/capital/mocks/mock-data/capital.ts
@@ -186,7 +186,9 @@ export const WRITTEN_OFF_GRANT: IGrant = {
     status: 'WrittenOff',
 };
 
-export const GRANTS: IGrant[] = [ACTIVE_GRANT, REPAID_GRANT, REVOKED_GRANT, WRITTEN_OFF_GRANT, FAILED_GRANT];
+export const ACTIVE_RENEWING_GRANT: IGrant = { ...ACTIVE_GRANT, renewsGrantId: REPAID_GRANT.id };
+
+export const GRANTS: IGrant[] = [ACTIVE_RENEWING_GRANT, REPAID_GRANT, REVOKED_GRANT, WRITTEN_OFF_GRANT, FAILED_GRANT];
 
 export const SIGNED_OFFER = {
     id: '66e12a9a64a6',
@@ -296,7 +298,7 @@ export const CAPITAL_STATE_PENDING_GRANT_WITH_MULTIPLE_ACTIONS: ICapitalState = 
 };
 
 export const CAPITAL_STATE_GRANTS: ICapitalState = {
-    activeOrPendingGrants: [ACTIVE_GRANT],
+    activeOrPendingGrants: [ACTIVE_RENEWING_GRANT],
     dynamicOffer: DYNAMIC_CAPITAL_OFFER,
     hasClosedGrants: true,
 };

--- a/packages/domains/capital/preact/src/CapitalOverview/components/CapitalOverview/CapitalOverview.tsx
+++ b/packages/domains/capital/preact/src/CapitalOverview/components/CapitalOverview/CapitalOverview.tsx
@@ -73,7 +73,7 @@ export const CapitalOverview: FunctionalComponent<ExternalUIComponentProps<Capit
 
     const grantList = useMemo(() => {
         const grants = requestedGrant ? [requestedGrant, ...(grantsQuery.data?.data || [])] : grantsQuery.data?.data;
-        return grants?.filter(grant => !capitalState.renewsGrantIds.has(grant.id));
+        return grants?.filter(grant => !(grant.status === 'Active' && capitalState.renewsGrantIds.has(grant.id)));
     }, [capitalState.renewsGrantIds, grantsQuery.data?.data, requestedGrant]);
 
     const handlePreQualifiedFundsRequest = useCallback<OnFundsRequestCallback>(


### PR DESCRIPTION
Resolved an issue in capital overview component where a closed grant would be incorrectly hidden from the grant list if it was later renewed. Only active grants that are renewed are now filtered out of the list.