### PR TITLE
Add support to check Vue components availability

### DIFF
--- a/packages/shared/core/src/vue/ConfigContext/ConfigProvider.vue
+++ b/packages/shared/core/src/vue/ConfigContext/ConfigProvider.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { provide, reactive, ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import { provide, reactive, ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
 import { CONFIG_CONTEXT_KEY } from './constants';
 import { EMPTY_OBJECT } from '@integration-components/utils';
 import { checkComponentPermission, subscribeToSession } from '../../setupConfig';
@@ -60,15 +60,36 @@ function subscribe() {
 }
 
 onMounted(() => {
-    subscribe();
+    watch(
+        () => props.session,
+        () => {
+            initialized.value = false;
+            subscribe();
+        },
+        { immediate: true }
+    );
 
-    if (props.type) {
-        void checkComponentPermission(props.type, props.session).then(result => {
-            hasPermission.value = result;
-        });
-    } else {
-        hasPermission.value = true;
-    }
+    watch(
+        () => [props.type, props.session] as const,
+        ([type, session]) => {
+            if (!type) {
+                hasPermission.value = true;
+                return;
+            }
+
+            hasPermission.value = undefined;
+            checkComponentPermission(type, session)
+                .then(result => {
+                    hasPermission.value = result;
+                })
+                // Fail closed: if the availability check errors out, treat the component as unavailable
+                // rather than leaving it stuck on the loading state.
+                .catch(() => {
+                    hasPermission.value = false;
+                });
+        },
+        { immediate: true }
+    );
 });
 
 onBeforeUnmount(() => {

--- a/packages/shared/core/src/vue/ConfigContext/ConfigProvider.vue
+++ b/packages/shared/core/src/vue/ConfigContext/ConfigProvider.vue
@@ -1,15 +1,27 @@
 <script setup lang="ts">
-import { provide, reactive, ref, onMounted, onBeforeUnmount } from 'vue';
+import { provide, reactive, ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import { CONFIG_CONTEXT_KEY } from './constants';
 import { EMPTY_OBJECT } from '@integration-components/utils';
-import { subscribeToSession } from '../../setupConfig';
+import { checkComponentPermission, subscribeToSession } from '../../setupConfig';
+import componentAvailabilityErrors from '../../session/utils/sessionAwareComponentAvailability/helpers/componentAvailabilityErrors';
+import ErrorMessageDisplay from '../components/ErrorMessageDisplay/ErrorMessageDisplay.vue';
+import type { TranslationKey } from '../../translations';
 import type { ConfigContextValue, ConfigProviderProps } from './types';
 import './Spinner.scss';
 
 const props = defineProps<ConfigProviderProps>();
 
 const initialized = ref(false);
+const hasPermission = ref<boolean | undefined>(undefined);
 let unsubscribe: (() => void) | undefined;
+
+const errorTitle: TranslationKey = 'common.errors.somethingWentWrong';
+const permissionResolved = computed(() => !props.type || hasPermission.value !== undefined);
+const permissionDenied = computed(() => hasPermission.value === false);
+const ready = computed(() => initialized.value && permissionResolved.value && !permissionDenied.value);
+const errorMessages = computed<TranslationKey[]>(() =>
+    props.type ? [componentAvailabilityErrors(props.type), 'common.errors.contactSupport'] : ['common.errors.contactSupport']
+);
 
 const configContextValue = reactive<ConfigContextValue>({
     get endpoints() {
@@ -37,9 +49,9 @@ function subscribe() {
     unsubscribe = subscribeToSession(props.session, {
         onContextChange: () => {
             const ctx = props.session.context;
-            const ready = ctx.endpoints !== EMPTY_OBJECT && !ctx.refreshing && !ctx.hasError;
+            const isReady = ctx.endpoints !== EMPTY_OBJECT && !ctx.refreshing && !ctx.hasError;
 
-            if (ready && !initialized.value) {
+            if (isReady && !initialized.value) {
                 initialized.value = true;
             }
         },
@@ -49,6 +61,14 @@ function subscribe() {
 
 onMounted(() => {
     subscribe();
+
+    if (props.type) {
+        void checkComponentPermission(props.type, props.session).then(result => {
+            hasPermission.value = result;
+        });
+    } else {
+        hasPermission.value = true;
+    }
 });
 
 onBeforeUnmount(() => {
@@ -57,7 +77,8 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-    <slot v-if="initialized" />
+    <ErrorMessageDisplay v-if="permissionDenied" centered :title="errorTitle" :message="errorMessages" />
+    <slot v-else-if="ready" />
     <slot v-else name="loading">
         <div class="adyen-pe-spinner__wrapper">
             <!-- TODO: Replace with actual loading indicator -->

--- a/packages/shared/core/src/vue/ConfigContext/types.ts
+++ b/packages/shared/core/src/vue/ConfigContext/types.ts
@@ -1,5 +1,6 @@
 import type { AuthSession } from '../../session/AuthSession';
 import type { SetupContextObject } from '../../ConfigContext.types';
+import type { ExternalComponentType } from '@integration-components/types';
 
 export interface ConfigContextValue {
     readonly endpoints: SetupContextObject['endpoints'];
@@ -11,4 +12,5 @@ export interface ConfigContextValue {
 
 export interface ConfigProviderProps {
     session: AuthSession;
+    type?: ExternalComponentType;
 }

--- a/packages/shared/core/src/vue/UIElementProvider.vue
+++ b/packages/shared/core/src/vue/UIElementProvider.vue
@@ -28,7 +28,7 @@ provide(COMPONENT_REF_KEY, componentRef);
         :get-cdn-dataset="props.core.getCdnDataset"
         :external-error-handler="props.core.options.onError"
     >
-        <ConfigProvider :session="props.core.session">
+        <ConfigProvider :session="props.core.session" :type="props.componentName">
             <EventDispatcherProvider :component-name="props.componentName" :analytics-enabled="props.core.analyticsEnabled ?? true">
                 <section ref="componentRef" :class="['adyen-pe-component', props.customClassNames]" data-testid="component-root">
                     <div class="adyen-pe-component__container">

--- a/packages/shared/core/src/vue/components/ErrorMessageDisplay/ErrorMessageDisplay.scss
+++ b/packages/shared/core/src/vue/components/ErrorMessageDisplay/ErrorMessageDisplay.scss
@@ -1,0 +1,39 @@
+@use '@integration-components/style';
+
+.adyen-pe-error-message-display {
+    border-radius: style.token(border-radius-m);
+    display: flex;
+    flex-direction: column;
+    gap: style.token(spacer-060);
+    margin: 0 auto;
+    max-width: 550px;
+    padding: style.token(spacer-090);
+    text-align: center;
+
+    &--outlined {
+        background: style.token(color-background-primary);
+        border: style.token(border-width-s) solid style.token(color-outline-primary);
+        box-shadow: 0 6px 12px 0 rgba(0, 17, 44, 0.08);
+    }
+
+    &--centered {
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    &__title {
+        font-size: style.token(text-title-m-font-size);
+        font-weight: style.token(text-body-strongest-font-weight);
+        letter-spacing: #{style.token(text-title-letter-spacing)};
+        line-height: style.token(text-title-m-mobile-line-height);
+        margin: 0;
+    }
+
+    &__message {
+        font-size: style.token(text-body-font-size);
+        font-weight: style.token(text-body-font-weight);
+        letter-spacing: #{style.token(text-body-letter-spacing)};
+        line-height: style.token(text-body-line-height);
+        margin: 0;
+    }
+}

--- a/packages/shared/core/src/vue/components/ErrorMessageDisplay/ErrorMessageDisplay.vue
+++ b/packages/shared/core/src/vue/components/ErrorMessageDisplay/ErrorMessageDisplay.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+// Uses plain elements + token SCSS instead of BentoTypography because shared/core
+// must not depend on @adyen/bento-vue3.
 import { computed } from 'vue';
 import { useCoreContext } from '../../Context/useCoreContext';
 import type { TranslationKey } from '../../../translations';

--- a/packages/shared/core/src/vue/components/ErrorMessageDisplay/ErrorMessageDisplay.vue
+++ b/packages/shared/core/src/vue/components/ErrorMessageDisplay/ErrorMessageDisplay.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useCoreContext } from '../../Context/useCoreContext';
+import type { TranslationKey } from '../../../translations';
+import './ErrorMessageDisplay.scss';
+
+const props = withDefaults(
+    defineProps<{
+        title: TranslationKey;
+        message?: TranslationKey | TranslationKey[];
+        centered?: boolean;
+        testId?: string;
+    }>(),
+    { centered: false, testId: 'error-message-display' }
+);
+
+const { i18n } = useCoreContext();
+
+const messages = computed<TranslationKey[]>(() => {
+    if (!props.message) return [];
+    return Array.isArray(props.message) ? props.message : [props.message];
+});
+</script>
+
+<template>
+    <div
+        :data-testid="props.testId"
+        :class="[
+            'adyen-pe-error-message-display',
+            'adyen-pe-error-message-display--outlined',
+            { 'adyen-pe-error-message-display--centered': props.centered },
+        ]"
+    >
+        <div class="adyen-pe-error-message-display__title">
+            {{ i18n.get(props.title) }}
+        </div>
+        <p v-if="messages.length" class="adyen-pe-error-message-display__message">
+            <template v-for="(msg, index) in messages" :key="msg">
+                <br v-if="index > 0" />
+                {{ i18n.get(msg) }}
+            </template>
+        </p>
+    </div>
+</template>


### PR DESCRIPTION
Add the component availability permission guard to the Vue shared `ConfigProvider` to match Preact version. Before, unavailable components rendered anyway, now they show the "component unavailable" error.